### PR TITLE
Add selective CPU test suites

### DIFF
--- a/docs/backend-validation-guide.md
+++ b/docs/backend-validation-guide.md
@@ -26,17 +26,45 @@ For current release/support scope, use:
 
 ### Functional and subsystem tests
 
-These run unconditionally in [`runtests.jl`](../test/runtests.jl) through the
-grouped testsets under [`test/testsets`](../test/testsets):
+Bare `Pkg.test()` runs every registered suite in
+[`runtests.jl`](../test/runtests.jl) through the grouped testsets under
+[`test/testsets`](../test/testsets):
 
-- core optics
-- atmosphere
+- quality, API, and deterministic RNG policy
+- KernelAbstractions CPU parity and tomography
+- core optics, direct science, and atmosphere
 - control and runtime
 - detectors and WFS
+- plant topology, preparation, product providers, RNG ownership, and
+  calibration illumination
 - calibration and analysis
-- reference and tutorial regression
+- reference, tutorial, and Gate 0 regression
 
 These are normal correctness tests, not backend throughput checks.
+
+For a development edit/test loop, pass one or more stable suite or group names
+through Julia's `test_args` interface. For example:
+
+```sh
+julia --project=. --startup-file=no -e \
+  'using Pkg; Pkg.test(test_args=["plant-time"])'
+
+julia --project=. --startup-file=no -e \
+  'using Pkg; Pkg.test(test_args=["plant"])'
+```
+
+The first command runs one fine-grained suite; the second runs the broader
+plant group. Multiple selectors form a de-duplicated union in canonical suite
+order. List the current suites and groups with:
+
+```sh
+julia --project=. --startup-file=no -e \
+  'using Pkg; Pkg.test(test_args=["--list"])'
+```
+
+An unknown selector fails rather than silently running no tests. Selective
+runs are development evidence only: bare `Pkg.test()` remains the complete CPU
+composition and release gate, and CI continues to run it.
 
 ### Optional backend smoke in `Pkg.test()`
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,14 @@
-include("runtests_head.jl")
+include("test_selection.jl")
 
-include("testsets/core_optics.jl")
-include("testsets/direct_science.jl")
-include("testsets/atmosphere.jl")
-include("testsets/plant_topology.jl")
-include("testsets/plant_time.jl")
-include("testsets/control_and_runtime.jl")
-include("testsets/detectors_and_wfs.jl")
-include("testsets/plant_preparation.jl")
-include("testsets/plant_providers.jl")
-include("testsets/plant_rng.jl")
-include("testsets/plant_illumination.jl")
-include("testsets/calibration_and_analysis.jl")
-include("testsets/reference_and_tutorials.jl")
-include("testsets/gate0_characterization.jl")
-
-include("backend_optional_common.jl")
-include("optional_amdgpu_backends.jl")
-include("optional_cuda_backends.jl")
+requested_suites = resolve_test_suites()
+if requested_suites === nothing
+    print_test_suite_help()
+else
+    include("runtests_head.jl")
+    for suite in requested_suites
+        @info "Running test suite" suite=suite.name
+        for path in suite.paths
+            include(path)
+        end
+    end
+end

--- a/test/runtests_head.jl
+++ b/test/runtests_head.jl
@@ -1,5 +1,4 @@
 using Test
-using Aqua
 using AdaptiveOpticsSim
 using LinearAlgebra
 using Random
@@ -40,25 +39,6 @@ using .SubaruAO3kSimulation
 
 include("reference_harness.jl")
 include("gate0_characterization_harness.jl")
-include("ka_cpu_matrix.jl")
-include("tomography.jl")
-
-_rng_family(::Xoshiro) = :xoshiro
-_rng_family(::MersenneTwister) = :mersenne_twister
-_rng_family(::AbstractRNG) = :other
-
-@testset "RNG policy helpers" begin
-    @test _rng_family(runtime_rng(1)) == :xoshiro
-    @test _rng_family(deterministic_reference_rng(1)) == :mersenne_twister
-    @test rand(runtime_rng(42), UInt64) == rand(runtime_rng(42), UInt64)
-    @test rand(deterministic_reference_rng(42), UInt64) == rand(deterministic_reference_rng(42), UInt64)
-    @test coverage_runner_flag("true")
-    @test coverage_runner_flag(" YES ")
-    @test !coverage_runner_flag("false")
-    @test coverage_instrumented() ==
-        (coverage_runner_flag(get(ENV, "ADAPTIVEOPTICS_TEST_COVERAGE",
-            "false")) || Base.JLOptions().code_coverage != 0)
-end
 
 function run_tutorial_example(name::AbstractString)
     path = joinpath(dirname(@__DIR__), "examples", "tutorials", name)
@@ -380,13 +360,4 @@ function moving_closed_loop_trace(;
     end
 
     return (; slope_norms, command_norms, wfs_energy, science_energy)
-end
-
-@test AdaptiveOpticsSim.PROJECT_STATUS == :in_development
-
-@testset "Aqua" begin
-    Aqua.test_all(
-        AdaptiveOpticsSim;
-        undocumented_names=false,
-    )
 end

--- a/test/test_selection.jl
+++ b/test/test_selection.jl
@@ -1,0 +1,183 @@
+struct TestSuiteSpec{P<:Tuple}
+    name::String
+    paths::P
+end
+
+TestSuiteSpec(name::AbstractString, paths::AbstractString...) =
+    TestSuiteSpec(String(name), Tuple(String.(paths)))
+
+# Registry order is the full-suite execution order. Keep it stable so bare
+# `Pkg.test()` remains the deterministic composition gate.
+const TEST_SUITE_SPECS = (
+    TestSuiteSpec("ka-cpu", "ka_cpu_matrix.jl"),
+    TestSuiteSpec("tomography", "tomography.jl"),
+    TestSuiteSpec("quality", "testsets/quality.jl"),
+    TestSuiteSpec("core-optics", "testsets/core_optics.jl"),
+    TestSuiteSpec("direct-science", "testsets/direct_science.jl"),
+    TestSuiteSpec("atmosphere", "testsets/atmosphere.jl"),
+    TestSuiteSpec("plant-topology", "testsets/plant_topology.jl"),
+    TestSuiteSpec("plant-time", "testsets/plant_time.jl"),
+    TestSuiteSpec("runtime", "testsets/control_and_runtime.jl"),
+    TestSuiteSpec(
+        "detectors-wfs",
+        "testsets/detectors.jl",
+        "testsets/wfs_stage_contracts.jl",
+        "testsets/shack_hartmann_and_sources.jl",
+        "testsets/pyramid_bioedge_and_lgs.jl",
+        "testsets/zernike_and_curvature.jl",
+    ),
+    TestSuiteSpec("plant-preparation", "testsets/plant_preparation.jl"),
+    TestSuiteSpec("plant-providers", "testsets/plant_providers.jl"),
+    TestSuiteSpec("plant-rng", "testsets/plant_rng.jl"),
+    TestSuiteSpec("plant-illumination", "testsets/plant_illumination.jl"),
+    TestSuiteSpec(
+        "calibration-analysis",
+        "testsets/calibration_and_analysis.jl",
+    ),
+    TestSuiteSpec(
+        "reference-tutorials",
+        "testsets/reference_and_tutorials.jl",
+    ),
+    TestSuiteSpec("gate0", "testsets/gate0_characterization.jl"),
+    TestSuiteSpec(
+        "backend-smoke",
+        "backend_optional_common.jl",
+        "optional_amdgpu_backends.jl",
+        "optional_cuda_backends.jl",
+    ),
+)
+
+const TEST_GROUP_SPECS = (
+    "core" => ("core-optics", "direct-science", "atmosphere"),
+    "plant" => (
+        "plant-topology",
+        "plant-time",
+        "plant-preparation",
+        "plant-providers",
+        "plant-rng",
+        "plant-illumination",
+    ),
+    "control" => ("tomography", "runtime", "calibration-analysis"),
+    "sensors" => ("detectors-wfs",),
+    "references" => ("reference-tutorials", "gate0"),
+    "backends" => ("ka-cpu", "backend-smoke"),
+)
+
+test_suite_names() = Tuple(spec.name for spec in TEST_SUITE_SPECS)
+test_group_names() = Tuple(first(group) for group in TEST_GROUP_SPECS)
+
+function _test_suite_spec(name::AbstractString)
+    for spec in TEST_SUITE_SPECS
+        spec.name == name && return spec
+    end
+    return nothing
+end
+
+function _test_group_members(name::AbstractString)
+    for (group_name, members) in TEST_GROUP_SPECS
+        group_name == name && return members
+    end
+    return nothing
+end
+
+function validate_test_suite_registry()
+    suite_names = test_suite_names()
+    length(unique(suite_names)) == length(suite_names) ||
+        throw(ArgumentError("test suite names must be unique"))
+
+    group_names = test_group_names()
+    length(unique(group_names)) == length(group_names) ||
+        throw(ArgumentError("test group names must be unique"))
+    isempty(intersect(Set(suite_names), Set(group_names))) || throw(
+        ArgumentError("test suite and group names must not overlap"),
+    )
+
+    registered_paths = String[]
+    for spec in TEST_SUITE_SPECS
+        isempty(spec.paths) && throw(ArgumentError(
+            "test suite '$(spec.name)' must register at least one path"))
+        append!(registered_paths, spec.paths)
+    end
+    length(unique(registered_paths)) == length(registered_paths) ||
+        throw(ArgumentError("test paths must belong to exactly one suite"))
+
+    known_suites = Set(suite_names)
+    for (group_name, members) in TEST_GROUP_SPECS
+        isempty(members) && throw(ArgumentError(
+            "test group '$group_name' must contain at least one suite"))
+        for member in members
+            member in known_suites || throw(ArgumentError(
+                "test group '$group_name' names unknown suite '$member'"))
+        end
+    end
+    return nothing
+end
+
+validate_test_suite_registry()
+
+function _test_selector_error(selector::AbstractString)
+    known = join(("all", test_suite_names()..., test_group_names()...), ", ")
+    return ArgumentError(
+        "unknown test selector '$selector'; expected one of: $known",
+    )
+end
+
+"""
+    resolve_test_suites(arguments=ARGS)
+
+Resolve suite and group selectors in canonical registry order. Empty arguments
+select the complete suite. `--list` returns `nothing` and must be used alone.
+Duplicate or overlapping selectors are idempotent.
+"""
+function resolve_test_suites(arguments=ARGS)
+    selectors = String[String(argument) for argument in arguments]
+    isempty(selectors) && return TEST_SUITE_SPECS
+
+    if "--list" in selectors
+        all(==("--list"), selectors) || throw(ArgumentError(
+            "--list cannot be combined with test suite selectors"))
+        return nothing
+    end
+    if "all" in selectors
+        all(==("all"), selectors) || throw(ArgumentError(
+            "all cannot be combined with other test suite selectors"))
+        return TEST_SUITE_SPECS
+    end
+
+    selected_names = Set{String}()
+    for selector in selectors
+        suite = _test_suite_spec(selector)
+        if suite !== nothing
+            push!(selected_names, suite.name)
+            continue
+        end
+
+        members = _test_group_members(selector)
+        members === nothing && throw(_test_selector_error(selector))
+        union!(selected_names, members)
+    end
+    return Tuple(spec for spec in TEST_SUITE_SPECS
+        if spec.name in selected_names)
+end
+
+function print_test_suite_help(io::IO=stdout)
+    println(io, "Test suites:")
+    for spec in TEST_SUITE_SPECS
+        println(io, "  ", spec.name)
+    end
+    println(io, "Test groups:")
+    for (name, members) in TEST_GROUP_SPECS
+        println(io, "  ", name, " = ", join(members, ", "))
+    end
+    println(io, "Special selectors: all, --list")
+    return nothing
+end
+
+function registered_testset_paths()
+    paths = String[]
+    for spec in TEST_SUITE_SPECS, path in spec.paths
+        startswith(path, "testsets/") || continue
+        push!(paths, normpath(joinpath(@__DIR__, path)))
+    end
+    return sort!(paths)
+end

--- a/test/testsets/detectors_and_wfs.jl
+++ b/test/testsets/detectors_and_wfs.jl
@@ -1,5 +1,0 @@
-include("detectors.jl")
-include("wfs_stage_contracts.jl")
-include("shack_hartmann_and_sources.jl")
-include("pyramid_bioedge_and_lgs.jl")
-include("zernike_and_curvature.jl")

--- a/test/testsets/quality.jl
+++ b/test/testsets/quality.jl
@@ -1,0 +1,73 @@
+using Aqua
+
+_rng_family(::Xoshiro) = :xoshiro
+_rng_family(::MersenneTwister) = :mersenne_twister
+_rng_family(::AbstractRNG) = :other
+
+@testset "RNG policy helpers" begin
+    @test _rng_family(runtime_rng(1)) == :xoshiro
+    @test _rng_family(deterministic_reference_rng(1)) == :mersenne_twister
+    @test rand(runtime_rng(42), UInt64) == rand(runtime_rng(42), UInt64)
+    @test rand(deterministic_reference_rng(42), UInt64) ==
+        rand(deterministic_reference_rng(42), UInt64)
+    @test coverage_runner_flag("true")
+    @test coverage_runner_flag(" YES ")
+    @test !coverage_runner_flag("false")
+    @test coverage_instrumented() ==
+        (coverage_runner_flag(get(ENV, "ADAPTIVEOPTICS_TEST_COVERAGE",
+            "false")) || Base.JLOptions().code_coverage != 0)
+end
+
+@test AdaptiveOpticsSim.PROJECT_STATUS == :in_development
+
+@testset "Selective test registry" begin
+    @test resolve_test_suites(String[]) === TEST_SUITE_SPECS
+    @test resolve_test_suites(["all"]) === TEST_SUITE_SPECS
+    @test resolve_test_suites(("all", "all")) === TEST_SUITE_SPECS
+    @test isnothing(resolve_test_suites(["--list"]))
+    @test isnothing(resolve_test_suites(("--list", "--list")))
+    @test Tuple(spec.name for spec in resolve_test_suites(
+        ["plant-topology"])) == ("plant-topology",)
+    @test Tuple(spec.name for spec in resolve_test_suites(
+        ["plant-time"])) == ("plant-time",)
+    @test Tuple(spec.name for spec in resolve_test_suites(["plant"])) == (
+        "plant-topology",
+        "plant-time",
+        "plant-preparation",
+        "plant-providers",
+        "plant-rng",
+        "plant-illumination",
+    )
+    @test Tuple(spec.name for spec in resolve_test_suites(
+        ["plant", "plant-topology", "plant"])) == (
+        "plant-topology",
+        "plant-time",
+        "plant-preparation",
+        "plant-providers",
+        "plant-rng",
+        "plant-illumination",
+    )
+    @test_throws ArgumentError resolve_test_suites(["unknown"])
+    @test_throws ArgumentError resolve_test_suites(["all", "quality"])
+    @test_throws ArgumentError resolve_test_suites(["--list", "quality"])
+
+    listing = IOBuffer()
+    @test isnothing(print_test_suite_help(listing))
+    listing_text = String(take!(listing))
+    @test occursin("plant-topology", listing_text)
+    @test occursin("plant-time", listing_text)
+    @test occursin("plant =", listing_text)
+
+    actual_testsets = sort!(filter(
+        path -> endswith(path, ".jl"),
+        readdir(@__DIR__; join=true),
+    ))
+    @test registered_testset_paths() == normpath.(actual_testsets)
+end
+
+@testset "Aqua" begin
+    Aqua.test_all(
+        AdaptiveOpticsSim;
+        undocumented_names=false,
+    )
+end


### PR DESCRIPTION
Closes #52.

## Summary

- register stable fine-grained CPU test suites and broader subsystem groups
- resolve selectors through Julia's supported `Pkg.test(test_args=[...])` interface
- preserve empty arguments and `all` as the complete canonical composition
- move KA, tomography, RNG-policy, registry, and Aqua execution out of bootstrap side effects
- reject unknown/conflicting selectors and provide a `--list` mode
- verify every file under `test/testsets` belongs to exactly one registered suite
- document focused development commands while retaining bare `Pkg.test()` as the release gate
- include the merged Gate 3 `plant-time` suite in both the fine-grained registry and broader `plant` group

## Why

The complete CPU suite is valuable but too slow for every edit/test cycle. Independent detector, plant-materialization, RNG, KA, reference, and tutorial blocks were being executed even for a small timing, topology, or API change.

## Measured local evidence

Julia 1.12.6, one thread, warm package depot:

- `plant-time`: 9.6 seconds, 156 checks
- `plant-topology`: 9.9 seconds, 164 checks
- `quality`: 25.3 seconds, including Aqua
- `core` group: 59.9 seconds
- bare full suite: 826.7 seconds (13m46.7s), passed

These are descriptive measurements, not timing assertions.

## Validation

- `Pkg.test(test_args=["plant-time"])` — passed after rebasing onto merged PR #51
- `Pkg.test(test_args=["plant-topology"])` — passed
- `Pkg.test(test_args=["quality"])` — passed after the final registry update
- `Pkg.test(test_args=["core"])` — passed
- `Pkg.test(test_args=["--list"])` — passed
- bare `Pkg.test()` — passed before the final rebase with every then-registered suite, existing allocation gates, references, and tutorials
- PR #51's complete Linux/macOS/Windows/Apple/coverage matrix passed for the added plant-time suite
- the final combined full composition is exercised by this PR's refreshed CI
- `git diff --check` — passed

## Exclusions

No scientific test, tolerance, allocation gate, backend check, or release-validation requirement is removed. CI sharding is deferred until the selector is proven; the first PR retains one full composition process on every existing CPU target.
