### PR TITLE
feat: expose run-bound event-loop acquisition products

### DIFF
--- a/src/plant/event_composition.jl
+++ b/src/plant/event_composition.jl
@@ -348,6 +348,7 @@ end
 struct _PreparedPlantEventAcquisition
     id::AcquisitionID
     lifecycle::_PreparedAcquisitionEventLifecycle
+    products::AcquisitionProducts
     product::Union{AbstractArray,WFSMeasurement}
     sample_provider::Union{Nothing,PreparedLinearReducedOrderEventProvider}
     rng::Xoshiro
@@ -1588,7 +1589,7 @@ function _prepare_event_acquisition_parts(plant::PreparedPlant,
     return owners, lifecycles, products, sample_providers, rngs, path_slots
 end
 
-function _prepare_event_acquisitions(definitions, lifecycles, products,
+function _prepare_event_acquisitions(definitions, owners, lifecycles, products,
     sample_providers, rngs, path_slots,
     scheduler::PreparedEventScheduler)
     acquisitions = Memory{_PreparedPlantEventAcquisition}(undef,
@@ -1597,6 +1598,7 @@ function _prepare_event_acquisitions(definitions, lifecycles, products,
         definition = definitions[index]
         acquisitions[index] = _PreparedPlantEventAcquisition(
             definition.acquisition, lifecycles[index],
+            acquisition_products(owners[index]),
             products[index], sample_providers[index], rngs[index],
             definition.start, UInt32(path_slots[index]),
             event_generator_handle(scheduler, ExposureOpenPhase,
@@ -1658,8 +1660,9 @@ function _prepare_plant_event_loop(
     path_groups = _prepare_path_execution_groups(
         plant, sample_definitions, owners, acquisition_definitions,
         path_slots, autonomous_definitions, scheduler)
-    acquisitions = _prepare_event_acquisitions(acquisition_definitions,
-        lifecycles, products, sample_providers, rngs, path_slots, scheduler)
+    acquisitions = _prepare_event_acquisitions(
+        acquisition_definitions, owners, lifecycles, products,
+        sample_providers, rngs, path_slots, scheduler)
     autonomous_optics = _prepare_event_autonomous_optics(
         autonomous_definitions, optics, path_groups,
         definition.trigger_topology)
@@ -1981,6 +1984,20 @@ end
 
 @inline _event_acquisition_slot(prepared::PreparedPlantEventLoop,
     name::Symbol) = _event_acquisition_slot(prepared, AcquisitionID(name))
+
+"""
+Return the exact run-bound products for one prepared event-loop acquisition.
+
+The returned wrapper and its storage are the same objects used by event-loop
+execution; this cold binding seam does not copy or transfer ownership.
+"""
+function acquisition_products(
+    prepared::PreparedPlantEventLoop,
+    id)
+    slot = _event_acquisition_slot(
+        prepared, _as_acquisition_id(id))
+    return @inbounds prepared.acquisitions[slot].products
+end
 
 function acquisition_product_sequence(prepared::PreparedPlantEventLoop,
     state::PlantEventLoopState, id)

--- a/test/testsets/plant_event_composition.jl
+++ b/test/testsets/plant_event_composition.jl
@@ -948,6 +948,21 @@ end
     @test plant_event_path_count(prepared) == 3
     @test path_execution_group_count(prepared) == 3
     @test plant_event_acquisition_count(prepared) == 5
+    for id in AcquisitionID.((
+        :lgs_emccd,
+        :ngs_saphira,
+        :science_ccd,
+        :science_cmos,
+        :science_rolling,
+    ))
+        @test acquisition_products(prepared, id) ===
+            acquisition_products(prepared_acquisition(plant, id))
+    end
+    unknown_products = event_test_error() do
+        acquisition_products(prepared, :unknown_acquisition)
+    end
+    @test unknown_products isa PlantScheduleError
+    @test unknown_products.reason == :unknown_acquisition
     @test plant_event_generator_count(prepared) == 1 + 3 + 5 * 5
     @test next_plant_event_timestamp(prepared, state, workspace) ==
         PlantTimestamp(0)

--- a/test/testsets/plant_reduced_order.jl
+++ b/test/testsets/plant_reduced_order.jl
@@ -360,6 +360,8 @@ end
     @test acquisition_product_ready_timestamp(first.prepared, first.state,
         :reduced_wfs) == PlantTimestamp(1_000_000)
     owner = prepared_acquisition(first.plant, :reduced_wfs)
+    @test acquisition_products(first.prepared, :reduced_wfs) ===
+        acquisition_products(owner)
     @test acquisition_provider_style(owner) isa
         CommandResponsiveReducedOrderProviderStyle
     @test acquisition_provider_payload_work(owner) ===


### PR DESCRIPTION
## Goal

Expose the exact acquisition-product storage retained by a prepared plant event loop so downstream orchestration cannot accidentally pair event-loop execution with products from another prepared plant.

## Changes

- retain each prepared acquisition's exact `AcquisitionProducts` wrapper in the event-loop binding
- add the HIL-neutral `acquisition_products(prepared_event_loop, acquisition)` cold binding seam
- preserve object identity; the accessor performs no copy and transfers no ownership
- reject unknown acquisition identities with the existing structured schedule error

## Validation

- `test/testsets/plant_event_composition.jl`: 243 passed, 1 existing broken
- `test/testsets/plant_reduced_order.jl`: reduced-order suites passed
- identity coverage includes full-optical multi-rate and reduced-order acquisitions
- local AdaptiveOpticsHIL serial integration against this branch: 134/134 passed
- `git diff --check`: clean

## Scope

This adds no HIL lifecycle, transport, ownership, or compatibility API to the core package. It is a cold prepared-binding seam used by the HIL companion.

Closes #124
