### PR TITLE
Expose bounded event-loop command failure drain

### DIFF
--- a/src/plant/event_composition.jl
+++ b/src/plant/event_composition.jl
@@ -2305,10 +2305,12 @@ end
         prepared, state, workspace, endpoint_id; reason=:endpoint_failure)
 
 Boundedly terminate every unclaimed pending command for one event-loop-owned
-endpoint at the current plant-event coordinate. Terminal dispositions are
-copied into the event loop's bounded ledger and the endpoint's command
-generator is rescheduled without changing its effective command or physical
-optic state.
+endpoint at its current canonical coordinate. An ingress admission may have
+advanced the endpoint beyond the scheduler's last processed plant event, so
+the failure coordinate is the later of those two coordinates. Terminal
+dispositions are copied into the event loop's bounded ledger and the
+endpoint's command generator is rescheduled without changing its effective
+command or physical optic state.
 """
 function fail_pending_plant_commands!(
     prepared::PreparedPlantEventLoop,
@@ -2324,7 +2326,9 @@ function fail_pending_plant_commands!(
     event_endpoint = _event_command_endpoint(prepared, slot)
     endpoint_state = _event_command_endpoint_state(state, slot)
     endpoint_workspace = _event_command_workspace(workspace, slot)
-    timestamp = scheduler_timestamp(state.scheduler)
+    timestamp = max(
+        scheduler_timestamp(state.scheduler),
+        command_endpoint_timestamp(endpoint_state))
     count = fail_pending_plant_commands!(
         endpoint_workspace,
         event_endpoint.binding.endpoint,

--- a/src/plant/event_composition.jl
+++ b/src/plant/event_composition.jl
@@ -2300,6 +2300,42 @@ function admit_plant_command!(prepared::PreparedPlantEventLoop,
     return admission
 end
 
+"""
+    fail_pending_plant_commands!(
+        prepared, state, workspace, endpoint_id; reason=:endpoint_failure)
+
+Boundedly terminate every unclaimed pending command for one event-loop-owned
+endpoint at the current plant-event coordinate. Terminal dispositions are
+copied into the event loop's bounded ledger and the endpoint's command
+generator is rescheduled without changing its effective command or physical
+optic state.
+"""
+function fail_pending_plant_commands!(
+    prepared::PreparedPlantEventLoop,
+    state::PlantEventLoopState,
+    workspace::PlantEventLoopWorkspace,
+    endpoint_id::CommandEndpointID;
+    reason=CommandDispositionReason(:endpoint_failure))
+    _require_plant_event_loop_binding(prepared, state)
+    _require_plant_event_loop_binding(prepared, workspace)
+    _require_idle_optical_path_batch(workspace)
+    _require_empty_event_command_dispositions(workspace)
+    slot = _event_command_endpoint_slot(prepared, endpoint_id)
+    event_endpoint = _event_command_endpoint(prepared, slot)
+    endpoint_state = _event_command_endpoint_state(state, slot)
+    endpoint_workspace = _event_command_workspace(workspace, slot)
+    timestamp = scheduler_timestamp(state.scheduler)
+    count = fail_pending_plant_commands!(
+        endpoint_workspace,
+        event_endpoint.binding.endpoint,
+        endpoint_state,
+        timestamp;
+        reason)
+    _append_event_command_dispositions!(workspace, endpoint_workspace)
+    _schedule_event_command_endpoint!(prepared, state, slot)
+    return count
+end
+
 @inline function _next_command_transaction_sequence(
     state::PlantEventLoopState)
     state.command_transaction_sequence != typemax(UInt64) ||

--- a/test/testsets/plant_command_composition.jl
+++ b/test/testsets/plant_command_composition.jl
@@ -487,6 +487,32 @@ end
     @test reordered.observation == result.observation
 end
 
+@testset "Event-loop command failure drain preserves the optic" begin
+    _, prepared, state, workspace, first_schema, _ =
+        command_composition_fixture()
+    admission = command_composition_submit!(
+        prepared, state, workspace, first_schema,
+        1, 100_000_000, 0.35)
+    @test command_admission_status(admission) ==
+        CommandAdmittedPending
+    @test effective_command(prepared, state, :a_woofer) == 0.0
+
+    count = @inferred fail_pending_plant_commands!(
+        prepared,
+        state,
+        workspace,
+        CommandEndpointID(:a_woofer);
+        reason=CommandDispositionReason(:hil_ingress_liveness_expired))
+    @test count == 1
+    @test command_disposition_count(workspace) == 1
+    disposition = command_disposition(workspace, 1)
+    @test command_terminal_kind(disposition) == FailedCommand
+    @test command_disposition_reason(disposition).name ==
+        :hil_ingress_liveness_expired
+    @test command_terminal_timestamp(disposition) == PlantTimestamp(0)
+    @test effective_command(prepared, state, :a_woofer) == 0.0
+end
+
 @testset "Prepared configuration and physical-state ownership" begin
     plant, _, _, _, _, _ = command_composition_fixture()
     definition = plant.definition

--- a/test/testsets/plant_command_composition.jl
+++ b/test/testsets/plant_command_composition.jl
@@ -490,9 +490,18 @@ end
 @testset "Event-loop command failure drain preserves the optic" begin
     _, prepared, state, workspace, first_schema, _ =
         command_composition_fixture()
-    admission = command_composition_submit!(
-        prepared, state, workspace, first_schema,
-        1, 100_000_000, 0.35)
+    @test step_plant_events!(prepared, state, workspace) ==
+        PlantTimestamp(0)
+    admission = admit_plant_command!(
+        prepared,
+        state,
+        workspace,
+        PlantCommand(
+            first_schema,
+            1,
+            PlantTimestamp(100_000_000),
+            0.35),
+        PlantTimestamp(1))
     @test command_admission_status(admission) ==
         CommandAdmittedPending
     @test effective_command(prepared, state, :a_woofer) == 0.0
@@ -509,7 +518,7 @@ end
     @test command_terminal_kind(disposition) == FailedCommand
     @test command_disposition_reason(disposition).name ==
         :hil_ingress_liveness_expired
-    @test command_terminal_timestamp(disposition) == PlantTimestamp(0)
+    @test command_terminal_timestamp(disposition) == PlantTimestamp(1)
     @test effective_command(prepared, state, :a_woofer) == 0.0
 end
 


### PR DESCRIPTION
## Summary

- expose the existing bounded pending-command failure drain through `PreparedPlantEventLoop`
- publish terminal dispositions through the composed event-loop ledger
- reschedule the endpoint generator while preserving the effective command and physical optic state

This is the narrow core seam required by AdaptiveOpticsHIL Gate 8.6 so an RTC-ingress-liveness failure can account for already admitted future-effective commands without reaching into event-loop internals.

## Validation

- `Pkg.test(test_args=["plant-command-composition"], coverage=false)`
- 185 assertions passed, including the new 8-assertion drain/optic-preservation case
- `git diff --check`

## Scope

No lifecycle coordinator, transport behavior, safe command, command-silence transition, or physical optic mutation is introduced.