### PR TITLE
Add fail-stop optical batch abandonment

### DIFF
--- a/src/plant/api.jl
+++ b/src/plant/api.jl
@@ -357,7 +357,7 @@ public begin_optical_path_batch!, materialize_path_execution_group!
 public materialize_device_path_batch!
 public seal_optical_path_batch_materialization!
 public execute_path_execution_group!, execute_device_path_batch!
-public complete_optical_path_batch!
+public complete_optical_path_batch!, abandon_optical_path_batch!
 public execute_optical_path_batch!
 public AbstractWaveformPhaseReference, AbstractAutonomousOpticFidelity
 public PreparedCircularPyramidModulator

--- a/src/plant/event_composition.jl
+++ b/src/plant/event_composition.jl
@@ -201,6 +201,7 @@ end
     _OpticalPathBatchMaterializing = 0x01
     _OpticalPathBatchExecuting = 0x02
     _OpticalPathBatchFinalizing = 0x03
+    _OpticalPathBatchAbandoned = 0x04
 end
 
 @enum _OpticalPathBatchGroupStatus::UInt8 begin
@@ -2320,7 +2321,7 @@ function fail_pending_plant_commands!(
     reason=CommandDispositionReason(:endpoint_failure))
     _require_plant_event_loop_binding(prepared, state)
     _require_plant_event_loop_binding(prepared, workspace)
-    _require_idle_optical_path_batch(workspace)
+    _require_command_failure_batch_state(workspace)
     _require_empty_event_command_dispositions(workspace)
     slot = _event_command_endpoint_slot(prepared, endpoint_id)
     event_endpoint = _event_command_endpoint(prepared, slot)
@@ -3934,6 +3935,19 @@ end
     return nothing
 end
 
+@inline function _require_command_failure_batch_state(
+    workspace::PlantEventLoopWorkspace)
+    phase = workspace.optical_path_batch.phase
+    phase in (
+        _OpticalPathBatchIdle,
+        _OpticalPathBatchAbandoned,
+    ) || _plant_event_loop_error(
+        :optical_path_batch_active,
+        "complete or explicitly abandon the active optical-path batch before failing pending commands",
+    )
+    return nothing
+end
+
 @inline function _next_optical_path_batch_generation(
     generation::UInt64,
 )
@@ -3979,6 +3993,7 @@ end
             "optical-path batch claim belongs to another event-loop state",
         )
     batch.phase != _OpticalPathBatchIdle &&
+        batch.phase != _OpticalPathBatchAbandoned &&
         batch.generation == claim.generation &&
         batch.scheduler_revision == claim.scheduler_revision &&
         batch.timestamp == claim.timestamp &&
@@ -4656,6 +4671,32 @@ function complete_optical_path_batch!(
     return claim.timestamp
 end
 
+"""
+    abandon_optical_path_batch!(prepared, state, workspace, claim)
+
+Relinquish the coordinator-local ownership of a failed optical-path batch
+without resolving its scheduler claims or attempting to undo any partially
+mutated plant, product, acquisition, atmosphere, or RNG state. The event loop
+is permanently fail-stopped after abandonment: only bounded terminal failure
+of pending commands remains permitted, and further admission or plant
+execution requires a fresh prepared run.
+"""
+function abandon_optical_path_batch!(
+    prepared::PreparedPlantEventLoop,
+    state::PlantEventLoopState,
+    workspace::PlantEventLoopWorkspace,
+    claim::OpticalPathBatchClaim,
+)
+    batch = _require_current_optical_path_batch(
+        prepared, state, workspace, claim)
+    fill!(workspace.due_paths, false)
+    fill!(batch.group_status, _OpticalPathBatchGroupNotDue)
+    batch.due_group_count = 0
+    batch.has_epoch = false
+    batch.phase = _OpticalPathBatchAbandoned
+    return claim.timestamp
+end
+
 function execute_optical_path_batch!(
     executor::AbstractOpticalPathBatchExecutor,
     ::PreparedPlantEventLoop,
@@ -4683,21 +4724,27 @@ function execute_optical_path_batch!(
 )
     claim = begin_optical_path_batch!(
         prepared, state, workspace, timestamp)
-    count = optical_path_batch_due_group_count(
-        prepared, state, workspace, claim)
-    @inbounds for index in 1:count
-        ordinal = optical_path_batch_due_group_ordinal(
-            prepared, state, workspace, claim, index)
-        _materialize_due_path_execution_group!(
-            prepared, state, workspace, claim, ordinal)
-    end
-    seal_optical_path_batch_materialization!(
-        prepared, state, workspace, claim)
-    @inbounds for index in 1:count
-        ordinal = optical_path_batch_due_group_ordinal(
-            prepared, state, workspace, claim, index)
-        _execute_due_path_execution_group!(
-            prepared, state, workspace, claim, ordinal)
+    try
+        count = optical_path_batch_due_group_count(
+            prepared, state, workspace, claim)
+        @inbounds for index in 1:count
+            ordinal = optical_path_batch_due_group_ordinal(
+                prepared, state, workspace, claim, index)
+            _materialize_due_path_execution_group!(
+                prepared, state, workspace, claim, ordinal)
+        end
+        seal_optical_path_batch_materialization!(
+            prepared, state, workspace, claim)
+        @inbounds for index in 1:count
+            ordinal = optical_path_batch_due_group_ordinal(
+                prepared, state, workspace, claim, index)
+            _execute_due_path_execution_group!(
+                prepared, state, workspace, claim, ordinal)
+        end
+    catch
+        abandon_optical_path_batch!(
+            prepared, state, workspace, claim)
+        rethrow()
     end
     return complete_optical_path_batch!(
         prepared, state, workspace, claim)

--- a/test/testsets/plant_command_composition.jl
+++ b/test/testsets/plant_command_composition.jl
@@ -10,6 +10,8 @@ struct CommandCompositionAcquisitionModel{T<:AbstractFloat}
 end
 
 struct ArrayInitialCommandOpticModel end
+struct AbandoningCommandCompositionBatchExecutor <:
+    Plant.AbstractOpticalPathBatchExecutor end
 
 struct PreparedCommandCompositionOptic{T<:AbstractFloat,
     A<:AbstractMatrix{T}}
@@ -246,6 +248,19 @@ function Plant.prepare_acquisition_provider(
             units=:detected_electrons,
             geometry=path.result.metadata))
     return prepare_full_optical_provider(execution, products)
+end
+
+function Plant.execute_optical_path_batch!(
+    ::AbandoningCommandCompositionBatchExecutor,
+    prepared::Plant.PreparedPlantEventLoop,
+    state::Plant.PlantEventLoopState,
+    workspace::Plant.PlantEventLoopWorkspace,
+    timestamp::PlantTimestamp,
+)
+    claim = Plant.begin_optical_path_batch!(
+        prepared, state, workspace, timestamp)
+    return Plant.abandon_optical_path_batch!(
+        prepared, state, workspace, claim)
 end
 
 function command_composition_schema(endpoint::Symbol;
@@ -520,6 +535,67 @@ end
         :hil_ingress_liveness_expired
     @test command_terminal_timestamp(disposition) == PlantTimestamp(1)
     @test effective_command(prepared, state, :a_woofer) == 0.0
+end
+
+@testset "Abandoned optical batch permits terminal command drain only" begin
+    _, prepared, state, workspace, first_schema, _ =
+        command_composition_fixture()
+    admission = admit_plant_command!(
+        prepared,
+        state,
+        workspace,
+        PlantCommand(
+            first_schema,
+            1,
+            PlantTimestamp(100_000_000),
+            0.35),
+        PlantTimestamp(0),
+    )
+    @test command_admission_status(admission) ==
+        CommandAdmittedPending
+
+    abandonment_error = captured_command_composition_error() do
+        step_plant_events!(
+            prepared,
+            state,
+            workspace,
+            AbandoningCommandCompositionBatchExecutor(),
+        )
+    end
+    @test abandonment_error isa PlantScheduleError
+    @test abandonment_error.reason == :optical_path_batch_active
+
+    count = @inferred fail_pending_plant_commands!(
+        prepared,
+        state,
+        workspace,
+        CommandEndpointID(:a_woofer);
+        reason=CommandDispositionReason(:hil_owner_failure),
+    )
+    @test count == 1
+    @test command_disposition_count(workspace) == 1
+    disposition = command_disposition(workspace, 1)
+    @test command_terminal_kind(disposition) == FailedCommand
+    @test command_disposition_reason(disposition).name ==
+        :hil_owner_failure
+    @test command_terminal_timestamp(disposition) == PlantTimestamp(0)
+    @test effective_command(prepared, state, :a_woofer) == 0.0
+
+    admission_error = captured_command_composition_error() do
+        admit_plant_command!(
+            prepared,
+            state,
+            workspace,
+            PlantCommand(
+                first_schema,
+                2,
+                PlantTimestamp(200_000_000),
+                0.5),
+            PlantTimestamp(1),
+        )
+    end
+    @test admission_error isa PlantScheduleError
+    @test admission_error.reason == :optical_path_batch_active
 end
 
 @testset "Prepared configuration and physical-state ownership" begin

--- a/test/testsets/plant_event_composition.jl
+++ b/test/testsets/plant_event_composition.jl
@@ -91,6 +91,13 @@ end
 
 @inline event_composition_execution_probe!(::Nothing) = nothing
 
+struct EventCompositionFailureProbe
+    error::Exception
+end
+
+event_composition_execution_probe!(
+    probe::EventCompositionFailureProbe) = throw(probe.error)
+
 function event_composition_execution_probe!(
     probe::EventCompositionConcurrencyProbe,
 )
@@ -1046,6 +1053,7 @@ end
         :seal_optical_path_batch_materialization!,
         :execute_path_execution_group!,
         :complete_optical_path_batch!,
+        :abandon_optical_path_batch!,
         :execute_optical_path_batch!,
     )
         @test Base.ispublic(Plant, name)
@@ -1203,6 +1211,91 @@ end
         end
         @test stale_error isa PlantScheduleError
         @test stale_error.reason == :stale_optical_path_batch_claim
+
+        _, abandoned_prepared, abandoned_state, abandoned_workspace =
+            event_composition_fixture(aligned_optical_samples=true)
+        abandoned_claim = Plant.begin_optical_path_batch!(
+            abandoned_prepared,
+            abandoned_state,
+            abandoned_workspace,
+            PlantTimestamp(0),
+        )
+        @test @inferred(Plant.abandon_optical_path_batch!(
+            abandoned_prepared,
+            abandoned_state,
+            abandoned_workspace,
+            abandoned_claim,
+        )) == PlantTimestamp(0)
+        abandoned_claim_error = event_test_error() do
+            Plant.optical_path_batch_due_group_count(
+                abandoned_prepared,
+                abandoned_state,
+                abandoned_workspace,
+                abandoned_claim,
+            )
+        end
+        @test abandoned_claim_error isa PlantScheduleError
+        @test abandoned_claim_error.reason ==
+            :stale_optical_path_batch_claim
+        abandoned_step_error = event_test_error() do
+            step_plant_events!(
+                abandoned_prepared,
+                abandoned_state,
+                abandoned_workspace,
+            )
+        end
+        @test abandoned_step_error isa PlantScheduleError
+        @test abandoned_step_error.reason == :optical_path_batch_active
+        abandoned_timestamp_error = event_test_error() do
+            next_plant_event_timestamp(
+                abandoned_prepared,
+                abandoned_state,
+                abandoned_workspace,
+            )
+        end
+        @test abandoned_timestamp_error isa PlantScheduleError
+        @test abandoned_timestamp_error.reason ==
+            :optical_path_batch_active
+        repeated_abandonment_error = event_test_error() do
+            Plant.abandon_optical_path_batch!(
+                abandoned_prepared,
+                abandoned_state,
+                abandoned_workspace,
+                abandoned_claim,
+            )
+        end
+        @test repeated_abandonment_error isa PlantScheduleError
+        @test repeated_abandonment_error.reason ==
+            :stale_optical_path_batch_claim
+
+        serial_failure = ErrorException(
+            "intentional serial optical-path failure")
+        _, serial_failure_prepared, serial_failure_state,
+            serial_failure_workspace = event_composition_fixture(
+                aligned_optical_samples=true,
+                execution_probe=EventCompositionFailureProbe(
+                    serial_failure),
+            )
+        observed_serial_failure = event_test_error() do
+            step_plant_events!(
+                serial_failure_prepared,
+                serial_failure_state,
+                serial_failure_workspace,
+            )
+        end
+        @test observed_serial_failure === serial_failure
+        @test serial_failure_workspace.optical_path_batch.phase ==
+            Plant._OpticalPathBatchAbandoned
+        serial_failure_step_error = event_test_error() do
+            step_plant_events!(
+                serial_failure_prepared,
+                serial_failure_state,
+                serial_failure_workspace,
+            )
+        end
+        @test serial_failure_step_error isa PlantScheduleError
+        @test serial_failure_step_error.reason ==
+            :optical_path_batch_active
 
         _, stale_prepared, stale_state, stale_workspace =
             event_composition_fixture(aligned_optical_samples=true)
@@ -1524,6 +1617,22 @@ end
             @test signature.execution <= 512
             @test signature.completion == 0
             @test sum(signature) <= 2_048
+
+            _, abandonment_prepared, abandonment_state,
+                abandonment_workspace = event_composition_fixture(
+                    aligned_optical_samples=true)
+            abandonment_claim = Plant.begin_optical_path_batch!(
+                abandonment_prepared,
+                abandonment_state,
+                abandonment_workspace,
+                PlantTimestamp(0),
+            )
+            @test @allocated(Plant.abandon_optical_path_batch!(
+                abandonment_prepared,
+                abandonment_state,
+                abandonment_workspace,
+                abandonment_claim,
+            )) == 0
         end
     end
 


### PR DESCRIPTION
## Summary
- add an explicit, non-rollback abandonment transition for failed optical-path batches
- permanently fail-stop plant execution while permitting bounded terminal failure of pending commands
- cover stale claims, forbidden restart/admission, command disposition, and zero-allocation abandonment

This is a core prerequisite for AdaptiveOpticsHIL.jl Gate 8.8 failure coordination.

## Validation
- `Pkg.test(test_args=["plant-event-composition", "plant-command-composition"])`
- `Pkg.test(test_args=["plant-event-composition"])` after allocation coverage
- `Pkg.test(test_args=["quality"])`