### PR TITLE
NS-04B: complete Detectors counting and channel ownership

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,9 +21,9 @@ enter the caller's ordinary namespace. The root package exports the
 `Backends`, `Optics`, `Detectors`, and `Plant` modules, not compatibility
 exports for their moved contents.
 
-The breaking namespace migration is in progress. `Backends` and `Optics` are
-complete; `Detectors` owns the conventional frame/area surface, while
-counting/channel names remain at the root until NS-04B. `Optics` owns
+The breaking namespace migration is in progress. `Backends`, `Optics`, and
+`Detectors` are complete. `Detectors` owns both conventional frame/area and
+counting/channel sensor APIs. `Optics` owns
 apertures, telescopes, sources, optical products and
 metadata, pupil/field formation, backend-portable Fraunhofer and Fresnel
 propagation, direct imaging, sampled OPD, physical NCPA, controllable optics,
@@ -929,18 +929,17 @@ influence basis already includes the print-through structure.
 
 Import conventional frame and area-detector vocabulary with
 `using AdaptiveOpticsSim.Detectors`. The root exports the `Detectors` module,
-not these moved bindings. Counting/channel detector names remain on the root
-surface until the NS-04B ownership gate.
+not the moved detector bindings.
 
 - Conventional frame/area detector: `Detectors.Detector`
-- Counting/channel detectors (root-owned until NS-04B): `LinearAPDDetector`,
-  `APDDetector`, `SPADArrayDetector`, and `MKIDArrayDetector`
+- Counting/channel detectors: `LinearAPDDetector`, `APDDetector`,
+  `SPADArrayDetector`, and `MKIDArrayDetector`
 - Noise: `NoiseModel`, `NoiseNone`, `NoisePhoton`, `NoiseReadout`,
   `NoisePhotonReadout`
 - Conventional sensor families: `SensorType`, `CCDSensor`, `CMOSSensor`,
   `EMCCDSensor`, `InGaAsSensor`, and `HgCdTeAvalancheArraySensor`
-- Counting sensor families (root-owned until NS-04B): `APDSensor`,
-  `SPADArraySensor`, and `MKIDArraySensor`
+- Counting sensor families: `APDSensor`, `SPADArraySensor`, and
+  `MKIDArraySensor`
 - EMCCD modes and helpers: `LinearEMMode`, `PhotonCountingEMMode`,
   `EMOutput`, `ConventionalOutput`, `emccd_snr`
 - Linear APD topology: `SingleElementAPD`, `APDChannelBank`; analog APD output

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -79,11 +79,10 @@ function rather than introducing a second root function identity.
 ### Namespace Authority
 
 The package is transitioning from the original flat root surface to real
-domain modules alongside the existing `Plant` module. `Backends` and `Optics`
-are complete, and NS-04A makes `Detectors` the canonical owner of conventional
-frame/area detector models and acquisition. Counting/channel APIs remain on
-the root surface until NS-04B, while sharing the same internal detector type
-graph. `Optics` owns apertures, telescopes, sources, optical
+domain modules alongside the existing `Plant` module. `Backends`, `Optics`,
+and `Detectors` are complete. `Detectors` is the canonical owner of both
+conventional frame/area and counting/channel detector models and acquisition,
+with one shared detector type graph. `Optics` owns apertures, telescopes, sources, optical
 location/product metadata, pupil and field formation, general Fraunhofer and
 Fresnel propagation, direct imaging, sampled OPD, physical NCPA, controllable
 optics, and reusable physical WFS components. `Atmospheres`, `Detectors`,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -306,9 +306,9 @@ first-call evidence in
 These contracts contain no implementation binding moves.
 The maintained implementation stage lives in
 [`namespace_migration_state.toml`](../test/contracts/namespace_migration_state.toml);
-`Backends` and `Optics` are complete through NS-03. NS-04A establishes the
-conventional frame/area surface under `Detectors`; counting/channel APIs remain
-on the root surface until NS-04B. `Optics` owns apertures,
+`Backends`, `Optics`, and `Detectors` are complete through NS-04B.
+`Detectors` owns both conventional frame/area and counting/channel APIs.
+`Optics` owns apertures,
 telescopes, sources, optical locations/products, fields, general propagation,
 direct imaging, sampled OPD, physical NCPA, controllable optics, and reusable
 physical WFS components without changing the frozen final ownership target.

--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -226,14 +226,11 @@ include("core/telemetry.jl")
 
 include("detectors/detectors.jl")
 
-# Counting/channel detector APIs remain root-owned until NS-04B. Their
-# implementation shares the Detectors type graph so there is still exactly one
-# detector trait identity while the public surface migrates in bounded gates.
+# Detector implementations have one authoritative type and generic-function
+# owner. Root composition imports only the internal seams still required by
+# domains that have not yet completed their namespace migrations.
 using .Detectors
 import .Detectors:
-    APDChannelBank,
-    APDDetector,
-    APDSensor,
     AbstractChargeCouplingModel,
     AbstractCountingDetector,
     AbstractCountingCorrelationModel,
@@ -248,28 +245,14 @@ import .Detectors:
     AbstractQuantumEfficiencyModel,
     BackgroundModel,
     CountingReadoutMetadata,
-    CountingDeadTimeModel,
     CountingSensorType,
     FrameSamplingMode,
     FrameSensorType,
-    DutyCycleGate,
-    AfterpulsingModel,
-    ChannelCrosstalkModel,
-    CompositeCountingCorrelation,
-    LinearAPDDetector,
-    MKIDArrayDetector,
-    MKIDArraySensor,
     NoBackground,
-    NoDeadTime,
-    NonParalyzableDeadTime,
     NullChargeCoupling,
     NullDetectorDefectModel,
-    ParalyzableDeadTime,
     SampledQuantumEfficiency,
     ScalarQuantumEfficiency,
-    SPADArrayDetector,
-    SPADArraySensor,
-    SingleElementAPD,
     _copy_windowed_sampling_plane!,
     _raw_sampling_sigma,
     _require_finite_nonnegative_intensity,
@@ -285,7 +268,6 @@ import .Detectors:
     capture_stack!,
     capture_stack_with_quantum_efficiency!,
     capture_with_quantum_efficiency!,
-    channel_output,
     counting_array,
     counting_exposure_time,
     counting_fill_factor,

--- a/src/detectors/api.jl
+++ b/src/detectors/api.jl
@@ -1,10 +1,13 @@
 export Detector
+export APDDetector, LinearAPDDetector, SPADArrayDetector, MKIDArrayDetector
 export NoiseModel, NoiseNone, NoisePhoton, NoiseReadout, NoisePhotonReadout
 export SensorType, CCDSensor, CMOSSensor, EMCCDSensor, InGaAsSensor
 export LinearEMMode, PhotonCountingEMMode, EMOutput, ConventionalOutput
 export emccd_snr
 export SequentialAcquisition, FrameTransferAcquisition
 export HgCdTeAvalancheArraySensor
+export APDSensor, SPADArraySensor, MKIDArraySensor
+export SingleElementAPD, APDChannelBank
 export FrameResponseModel, NullFrameResponse, GaussianPixelResponse
 export SampledFrameResponse, RectangularPixelAperture
 export CMOSReadNoiseMap, InterpixelCapacitance, detector_mtf
@@ -26,7 +29,10 @@ export SaturatingFrameNonlinearity, ExponentialPersistence
 export AbstractDetectorThermalModel, NullDetectorThermalModel
 export FixedTemperature, FirstOrderThermalModel
 export ArrheniusRateLaw, LinearTemperatureLaw, ExponentialTemperatureLaw
-export capture!, output_frame, detector_export_metadata
+export CountingDeadTimeModel, NoDeadTime, NonParalyzableDeadTime
+export ParalyzableDeadTime, DutyCycleGate, AfterpulsingModel
+export ChannelCrosstalkModel, CompositeCountingCorrelation
+export capture!, output_frame, channel_output, detector_export_metadata
 export DetectorAcquisitionPlan, prepare_detector_acquisition
 export detector_ramp_slope, detector_ramp_intercept
 export detector_ramp_cube, detector_ramp_times

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -39,13 +39,6 @@ public atmosphere_direction_metadata, validate_atmosphere_direction_batch
 export advance!, advance_by!, advance_to!, propagate!
 export render_atmosphere!
 
-export APDDetector, LinearAPDDetector, SPADArrayDetector, MKIDArrayDetector
-export APDSensor, SPADArraySensor, MKIDArraySensor
-export SingleElementAPD, APDChannelBank
-export CountingDeadTimeModel, NoDeadTime, NonParalyzableDeadTime, ParalyzableDeadTime
-export DutyCycleGate, AfterpulsingModel, ChannelCrosstalkModel, CompositeCountingCorrelation
-export channel_output
-
 export Diffractive, Geometric
 export WFSObservationMetadata, WFSMeasurementMetadata
 export WFSObservation, WFSMeasurement

--- a/test/contracts/namespace_migration_state.toml
+++ b/test/contracts/namespace_migration_state.toml
@@ -2,131 +2,14 @@ schema_version = 1
 name = "namespace_migration_state"
 status = "maintained"
 authority = "namespace_authority.toml"
-current_gate = "NS-04A"
-implemented_owners = ["Backends", "Optics"]
-partial_owners = ["Detectors"]
+current_gate = "NS-04B"
+implemented_owners = ["Backends", "Optics", "Detectors"]
+partial_owners = []
 
 [owner_sources]
 Backends = "src/backends/api.jl"
 Optics = "src/optics/api.jl"
-
-[partial_owner_sources]
 Detectors = "src/detectors/api.jl"
-
-[partial_owner_bindings.Detectors]
-exports = [
-    "Detector",
-    "NoiseModel",
-    "NoiseNone",
-    "NoisePhoton",
-    "NoiseReadout",
-    "NoisePhotonReadout",
-    "SensorType",
-    "CCDSensor",
-    "CMOSSensor",
-    "EMCCDSensor",
-    "InGaAsSensor",
-    "LinearEMMode",
-    "PhotonCountingEMMode",
-    "EMOutput",
-    "ConventionalOutput",
-    "emccd_snr",
-    "SequentialAcquisition",
-    "FrameTransferAcquisition",
-    "HgCdTeAvalancheArraySensor",
-    "FrameResponseModel",
-    "NullFrameResponse",
-    "GaussianPixelResponse",
-    "SampledFrameResponse",
-    "RectangularPixelAperture",
-    "CMOSReadNoiseMap",
-    "InterpixelCapacitance",
-    "detector_mtf",
-    "PixelResponseNonuniformity",
-    "DarkSignalNonuniformity",
-    "BadPixelMask",
-    "CompositeDetectorDefectModel",
-    "GlobalShutter",
-    "RollingShutter",
-    "RollingExposure",
-    "GlobalResetExposure",
-    "SingleRead",
-    "AveragedNonDestructiveReads",
-    "CorrelatedDoubleSampling",
-    "FowlerSampling",
-    "UpTheRampSampling",
-    "SkipperSampling",
-    "FunctionFrameSource",
-    "InPlaceFrameSource",
-    "FunctionExposureFrameSource",
-    "InPlaceExposureFrameSource",
-    "FrameReadoutCorrectionModel",
-    "NullFrameReadoutCorrection",
-    "ReferencePixelCommonModeCorrection",
-    "ReferenceRowCommonModeCorrection",
-    "ReferenceColumnCommonModeCorrection",
-    "ReferenceOutputCommonModeCorrection",
-    "CompositeFrameReadoutCorrection",
-    "FrameReadoutProducts",
-    "NoFrameReadoutProducts",
-    "MultiReadFrameReadoutProducts",
-    "UpTheRampReadoutProducts",
-    "SkipperReadoutProducts",
-    "HgCdTeReadoutProducts",
-    "SaturatingFrameNonlinearity",
-    "ExponentialPersistence",
-    "AbstractDetectorThermalModel",
-    "NullDetectorThermalModel",
-    "FixedTemperature",
-    "FirstOrderThermalModel",
-    "ArrheniusRateLaw",
-    "LinearTemperatureLaw",
-    "ExponentialTemperatureLaw",
-    "capture!",
-    "output_frame",
-    "detector_export_metadata",
-    "DetectorAcquisitionPlan",
-    "prepare_detector_acquisition",
-    "detector_ramp_slope",
-    "detector_ramp_intercept",
-    "detector_ramp_cube",
-    "detector_ramp_times",
-    "readout_ready",
-    "reset_integration!",
-    "thermal_model",
-]
-public = []
-internal = [
-    "AbstractEMCCDAcquisitionMode",
-    "AbstractFrameTimingModel",
-    "FrameSensorType",
-    "_copy_windowed_sampling_plane!",
-    "_raw_sampling_sigma",
-    "_require_prepared_acquisition",
-    "accumulate_incremental_charge_generation!",
-    "advance_thermal!",
-    "apply_avalanche_excess_noise!",
-    "apply_quantization!",
-    "capture_signal_pipeline!",
-    "ensure_up_the_ramp_products!",
-    "finalize_charge_transport!",
-    "finalize_incremental_capture!",
-    "finalize_scheduled_up_the_ramp_readout_products!",
-    "is_global_shutter",
-    "line_time",
-    "readout_products",
-    "sample_frame_read!",
-    "sampling_read_time",
-    "subtract_background_map!",
-    "update_sensor_persistence!",
-    "write_output!",
-    "_detector_value_plan",
-    "_poisson_noise_frame!",
-    "_randn_frame_noise!",
-    "can_apply_device_readout_correction",
-    "counting_output_execution_plan",
-    "detector_execution_plan",
-]
 
 [baseline_divergence]
 root_surface = "src/exports.jl"

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -96,7 +96,7 @@ end
     # distinguishes routine unqualified vocabulary from stable qualified API.
     @test length(root_exported) <= 500
     @test length(optics_exported) <= 160
-    @test length(detectors_exported) <= 85
+    @test length(detectors_exported) <= 105
     @test length(plant_exported) <= 100
     @test Base.isexported(AdaptiveOpticsSim, :Backends)
     @test Base.isexported(AdaptiveOpticsSim, :Optics)
@@ -242,6 +242,19 @@ end
         :detector_ramp_cube,
         :detector_ramp_times,
         :InterpixelCapacitance,
+        :APDDetector,
+        :LinearAPDDetector,
+        :SPADArrayDetector,
+        :MKIDArrayDetector,
+        :APDSensor,
+        :SPADArraySensor,
+        :MKIDArraySensor,
+        :SingleElementAPD,
+        :APDChannelBank,
+        :CountingDeadTimeModel,
+        :DutyCycleGate,
+        :ChannelCrosstalkModel,
+        :channel_output,
     )
         @test !Base.isexported(AdaptiveOpticsSim, name)
         @test !Base.ispublic(AdaptiveOpticsSim, name)
@@ -249,7 +262,6 @@ end
         @test Base.ispublic(Detectors, name)
         @test parentmodule(getfield(Detectors, name)) === Detectors
     end
-    @test Base.isexported(AdaptiveOpticsSim, :MKIDArrayDetector)
     @test Base.isexported(AdaptiveOpticsSim, :SimulationEnsemble)
     @test Base.isexported(AdaptiveOpticsSim, :FactorizedReconstructor)
     @test Base.isexported(AdaptiveOpticsSim, :ControlledReconstructor)


### PR DESCRIPTION
Closes #143.

## Requirement impact

- completes the frozen `AdaptiveOpticsSim.Detectors` export allowlist for APD/channel, SPAD, and MKID counting models
- removes the remaining counting/channel detector bindings from the root export surface
- promotes `Detectors` from partial to fully implemented ownership in the exact namespace migration state
- preserves explicit single-channel/vector versus area-array semantics and updates maintained API/architecture/roadmap guidance
- removes redundant root composition imports while retaining only internal seams needed by domains awaiting later namespace gates

## Deliberate exclusions

- no detector implementation, state, event ordering, timing, RNG, dead-time, noise, kernel, or accelerator-extension change
- no qualification expansion, correlated-noise model, event-stream transport, camera profile, or compatibility adapter

## Validation

- exact namespace authority: 2432/2432; HIL import inventory 93/93; correctness/performance baselines 92/92
- core API and optics: 1226/1226
- detector suite: 827/827; sampled parameter ownership 50/50
- prepared photon-counting WFS acquisition and common WFS contracts: green
- interface conformance: 213/213
- Aqua/quality: green
- KernelAbstractions CPU matrix: 193/193
- exact counting/channel owner assertions: 18/18

The immediately preceding merged NS-04A commit validated the same `Detectors`-owned counting implementations and extension hooks with scalar indexing disabled on AMDGPU (968/968) and CUDA (958/958). This PR changes only export/root ownership metadata and callers; it does not change those implementations or extensions.
