### PR TITLE
NS-06A: establish common WavefrontSensors contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you are working on validation, production support, or backend work, then use:
 ```julia
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 
 tel = Telescope(resolution=32, diameter=8.0, central_obstruction=0.1)
 src = Source(band=:I, magnitude=8.0)

--- a/benchmarks/benchmark_control_operators.jl
+++ b/benchmarks/benchmark_control_operators.jl
@@ -1,4 +1,5 @@
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.WavefrontSensors
 using LinearAlgebra
 using Random
 using Statistics

--- a/benchmarks/benchmark_cpu_hotpath_cards.jl
+++ b/benchmarks/benchmark_cpu_hotpath_cards.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using BenchmarkTools
 using LinearAlgebra
 

--- a/benchmarks/benchmark_gate0_latency.jl
+++ b/benchmarks/benchmark_gate0_latency.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
+using AdaptiveOpticsSim.WavefrontSensors
 using Base64
 using Dates
 using HdrHistogram

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
+using AdaptiveOpticsSim.WavefrontSensors
 using BenchmarkTools
 using Random
 
@@ -51,7 +52,7 @@ function bench_reconstructor()
     wfs = ShackHartmannWFS(tel; n_lenslets=4)
     imat = interaction_matrix(dm, wfs, PupilFunction(tel); amplitude=0.1)
     recon = ModalReconstructor(imat; gain=1.0)
-    slopes = AdaptiveOpticsSim.slopes(wfs)
+    slopes = AdaptiveOpticsSim.WavefrontSensors.slopes(wfs)
     return @benchmark reconstruct($recon, $slopes)
 end
 
@@ -61,7 +62,7 @@ function bench_reconstructor_inplace()
     wfs = ShackHartmannWFS(tel; n_lenslets=4)
     imat = interaction_matrix(dm, wfs, PupilFunction(tel); amplitude=0.1)
     recon = ModalReconstructor(imat; gain=1.0)
-    slopes = AdaptiveOpticsSim.slopes(wfs)
+    slopes = AdaptiveOpticsSim.WavefrontSensors.slopes(wfs)
     out = similar(slopes, size(recon.reconstructor, 1))
     return @benchmark reconstruct!($out, $recon, $slopes)
 end
@@ -134,7 +135,7 @@ function alloc_checks()
     wfs = ShackHartmannWFS(tel_r; n_lenslets=4)
     imat = interaction_matrix(dm, wfs, PupilFunction(tel_r); amplitude=0.1)
     recon = ModalReconstructor(imat; gain=1.0)
-    slopes = AdaptiveOpticsSim.slopes(wfs)
+    slopes = AdaptiveOpticsSim.WavefrontSensors.slopes(wfs)
     out = similar(slopes, size(recon.reconstructor, 1))
     reconstruct!(out, recon, slopes)
     alloc_recon = @allocated reconstruct!(out, recon, slopes)

--- a/benchmarks/support/closed_loop_workload.jl
+++ b/benchmarks/support/closed_loop_workload.jl
@@ -1,4 +1,5 @@
 using AdaptiveOpticsSim.Atmospheres
+using AdaptiveOpticsSim.WavefrontSensors
 
 mutable struct ClosedLoopWorkload{
     S,A,R,P,O,W,C,V,RNG,T,

--- a/benchmarks/support/gate7_single_gpu.jl
+++ b/benchmarks/support/gate7_single_gpu.jl
@@ -5,6 +5,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Plant
+using AdaptiveOpticsSim.WavefrontSensors
 
 const AOS = AdaptiveOpticsSim
 const AOSPlant = AdaptiveOpticsSim.Plant

--- a/benchmarks/support/revolt_like_hil_common.jl
+++ b/benchmarks/support/revolt_like_hil_common.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
+using AdaptiveOpticsSim.WavefrontSensors
 using Random
 using DelimitedFiles
 using SparseArrays

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1126,9 +1126,17 @@ derived MTF, QE, charge multiplication, or detector noise.
 
 Reusable physical components in this section—modulation models, microlens
 arrays, masks, phase spots, and defocus pairs—are imported from
-`AdaptiveOpticsSim.Optics`. Composed front ends, detector acquisition,
-observations, measurements, and estimators remain in the current WFS surface
-until the `WavefrontSensors` namespace gate.
+`AdaptiveOpticsSim.Optics`. Import the common sensing, product, prepared-stage,
+and capability vocabulary from its canonical owner:
+
+```julia
+using AdaptiveOpticsSim
+using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
+```
+
+The concrete WFS family bindings remain on the root surface only during their
+ordered namespace gates. Common contracts are not forwarded through the root.
 
 - Sensing modes: `Diffractive`, `Geometric`
 - Prepared products: `WFSObservationMetadata`, `WFSMeasurementMetadata`,

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -652,8 +652,9 @@ returned at a HIL/RTC boundary.
 
 ## Wavefront Sensors
 
-WFS families live in `src/wfs/`. Family-specific implementation should stay
-near the family, usually in the corresponding directory under `src/wfs/`.
+`WavefrontSensors` owns the common WFS contracts. Family-specific
+implementation stays near the family, usually in the corresponding directory
+under `src/wfs/`, and extends generics imported explicitly from that owner.
 
 New physical WFS work should first implement the prepared semantic stages:
 
@@ -681,17 +682,17 @@ owned by its product leaves remain mutable destinations for prepared optical
 formation.
 
 Extensions should call the qualified validation seams
-`AdaptiveOpticsSim.validate_wfs_optical_input`,
-`AdaptiveOpticsSim.validate_wfs_optical_products`,
-`AdaptiveOpticsSim.validate_wfs_observation` or
-`AdaptiveOpticsSim.validate_wfs_observations`, and
-`AdaptiveOpticsSim.validate_wfs_measurement` as applicable before returning a
-prepared plan. Every new prepared plan also implements its corresponding exact
-binding validator:
+`AdaptiveOpticsSim.WavefrontSensors.validate_wfs_optical_input`,
+`AdaptiveOpticsSim.WavefrontSensors.validate_wfs_optical_products`,
+`AdaptiveOpticsSim.WavefrontSensors.validate_wfs_observation` or
+`AdaptiveOpticsSim.WavefrontSensors.validate_wfs_observations`, and
+`AdaptiveOpticsSim.WavefrontSensors.validate_wfs_measurement` as applicable
+before returning a prepared plan. Every new prepared plan also implements its
+corresponding exact binding validator:
 
-- `AdaptiveOpticsSim.validate_wfs_optical_formation_binding`
-- `AdaptiveOpticsSim.validate_wfs_acquisition_binding`
-- `AdaptiveOpticsSim.validate_wfs_estimation_binding`
+- `AdaptiveOpticsSim.WavefrontSensors.validate_wfs_optical_formation_binding`
+- `AdaptiveOpticsSim.WavefrontSensors.validate_wfs_acquisition_binding`
+- `AdaptiveOpticsSim.WavefrontSensors.validate_wfs_estimation_binding`
 
 The containing plant owner calls these validators during construction, and the
 stage calls them again before mutation. They remain qualified extension APIs

--- a/docs/julia-tutorial-mappings.md
+++ b/docs/julia-tutorial-mappings.md
@@ -56,6 +56,7 @@ The snippets below assume:
 ```julia
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 ```
 
 ### Image formation

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -80,16 +80,17 @@ function rather than introducing a second root function identity.
 
 The package is transitioning from the original flat root surface to real
 domain modules alongside the existing `Plant` module. `Backends`, `Optics`,
-`Atmospheres`, and `Detectors` are complete. `Atmospheres` owns atmosphere
-models and state, source-direction rendering and batching, and
+`Atmospheres`, and `Detectors` are complete. The common `WavefrontSensors`
+contracts are established; concrete WFS families are moving through their
+remaining ordered gates. `Atmospheres` owns atmosphere models and state,
+source-direction rendering and batching, and
 atmosphere-coupled propagation. `Detectors` is the canonical owner of both
 conventional frame/area and counting/channel detector models and acquisition,
 with one shared detector type graph. `Optics` owns apertures, telescopes, sources, optical
 location/product metadata, pupil and field formation, general Fraunhofer and
 Fresnel propagation, direct imaging, sampled OPD, physical NCPA, controllable
-optics, and reusable physical WFS components. `WavefrontSensors`,
-`Calibration`, `Control`, `Tomography`, and `Ensembles` follow in dependency
-order. The
+optics, and reusable physical WFS components. `Calibration`, `Control`,
+`Tomography`, and `Ensembles` follow in dependency order. The
 authoritative pre-migration inventory, final exact API allowlists,
 extension-hook owners, and cross-module imports are frozen in
 [`../test/contracts/namespace_authority.toml`](../test/contracts/namespace_authority.toml).

--- a/docs/model-cookbook.md
+++ b/docs/model-cookbook.md
@@ -34,7 +34,9 @@ Update the path-owned pupil with `apply_opd!`, `render_atmosphere!`, or
 
 ```julia
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 
 tel = Telescope(resolution=32, diameter=8.0, central_obstruction=0.1)
 src = Source(band=:I, magnitude=8.0)
@@ -72,6 +74,8 @@ stages.
 
 ```julia
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.Detectors
+using AdaptiveOpticsSim.WavefrontSensors
 
 detector = Detector(
     noise=NoiseReadout(1.0),
@@ -129,6 +133,7 @@ without HIL scheduling:
 ```julia
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)
 interaction = interaction_matrix(

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -137,6 +137,7 @@ For a compact recipe-first version of this guide, use [model-cookbook.md](model-
 ```julia
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 
 tel = Telescope(resolution=32, diameter=8.0, central_obstruction=0.1)
 src = Source(band=:I, magnitude=8.0)

--- a/examples/closed_loop/run_cl.jl
+++ b/examples/closed_loop/run_cl.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop/run_cl_first_stage.jl
+++ b/examples/closed_loop/run_cl_first_stage.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_from_phase_screens.jl
+++ b/examples/closed_loop/run_cl_from_phase_screens.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_long_push_pull.jl
+++ b/examples/closed_loop/run_cl_long_push_pull.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop/run_cl_sinusoidal_modulation.jl
+++ b/examples/closed_loop/run_cl_sinusoidal_modulation.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_two_stages.jl
+++ b/examples/closed_loop/run_cl_two_stages.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_two_stages_atm_change.jl
+++ b/examples/closed_loop/run_cl_two_stages_atm_change.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_zernike.jl
+++ b/examples/closed_loop/run_cl_zernike.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop_demo.jl
+++ b/examples/closed_loop_demo.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 using LinearAlgebra
 using Random
 

--- a/examples/integrations/proper_hil_coronagraph.jl
+++ b/examples/integrations/proper_hil_coronagraph.jl
@@ -2,6 +2,7 @@ Base.find_package("Proper") === nothing &&
     error("Proper.jl is not available in the active environment. Install it with `using Pkg; Pkg.add(\"Proper\")`, or use `Pkg.develop(path=\"../proper.jl\")` for a sibling checkout, before running this example.")
 
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.WavefrontSensors
 using Proper
 
 include(joinpath(@__DIR__, "..", "support", "proper_hil_coronagraph_common.jl"))

--- a/examples/support/proper_hil_coronagraph_common.jl
+++ b/examples/support/proper_hil_coronagraph_common.jl
@@ -4,6 +4,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
+using AdaptiveOpticsSim.WavefrontSensors
 using Proper
 using Random
 

--- a/examples/support/subaru_ao188_simulation.jl
+++ b/examples/support/subaru_ao188_simulation.jl
@@ -5,6 +5,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
+using AdaptiveOpticsSim.WavefrontSensors
 using LinearAlgebra
 using Random
 using Statistics

--- a/examples/support/subaru_ao3k_simulation.jl
+++ b/examples/support/subaru_ao3k_simulation.jl
@@ -6,6 +6,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
+using AdaptiveOpticsSim.WavefrontSensors
 using .SubaruAO188Simulation
 
 export AO3kNIRPyramidModel, AO3kSimulationParams, subaru_ao3k_simulation

--- a/examples/tutorials/common.jl
+++ b/examples/tutorials/common.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.WavefrontSensors
 import AdaptiveOpticsSim.Optics: filter!
 using Logging
 using Random

--- a/examples/tutorials/shack_hartmann_subapertures.jl
+++ b/examples/tutorials/shack_hartmann_subapertures.jl
@@ -15,7 +15,7 @@ function main(; resolution::Int=24)
 
     layout = subaperture_layout(sh.front_end)
     calibration = subaperture_calibration(sh)
-    metadata = AdaptiveOpticsSim.wfs_output_metadata(sh)
+    metadata = AdaptiveOpticsSim.WavefrontSensors.wfs_output_metadata(sh)
 
     @info "Shack-Hartmann subaperture tutorial complete" n_valid=n_valid_subapertures(layout) pitch_m=layout.pitch_m centroid_response=calibration.centroid_response
     return (

--- a/ext/AdaptiveOpticsSimAMDGPUExt.jl
+++ b/ext/AdaptiveOpticsSimAMDGPUExt.jl
@@ -1,7 +1,7 @@
 module AdaptiveOpticsSimAMDGPUExt
 
 import AdaptiveOpticsSim
-import AdaptiveOpticsSim: Backends
+import AdaptiveOpticsSim: Backends, WavefrontSensors
 using AMDGPU
 using AbstractFFTs
 using KernelAbstractions
@@ -89,14 +89,14 @@ function Backends.execute_fft_plan!(buffer::AMDGPU.ROCArray, plan::AbstractFFTs.
 end
 AdaptiveOpticsSim.default_build_backend(::AMDGPU.ROCArray) = AdaptiveOpticsSim.GPUArrayBuildBackend(Backends.AMDGPUBackendTag)
 AdaptiveOpticsSim.prepare_build_matrix(::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag}, A::AbstractMatrix) = Matrix(A)
-AdaptiveOpticsSim.grouped_accumulation_plan(
+WavefrontSensors.grouped_accumulation_plan(
     ::Type{<:Backends.AcceleratorStyle{<:AMDGPU.ROCBackend}},
     ::Type{<:AdaptiveOpticsSim.PyramidWFS},
-) = AdaptiveOpticsSim.GroupedStaged2DPlan()
-AdaptiveOpticsSim.grouped_accumulation_plan(
+) = WavefrontSensors.GroupedStaged2DPlan()
+WavefrontSensors.grouped_accumulation_plan(
     ::Type{<:Backends.AcceleratorStyle{<:AMDGPU.ROCBackend}},
     ::Type{<:AdaptiveOpticsSim.BioEdgeWFS},
-) = AdaptiveOpticsSim.GroupedStaged2DPlan()
+) = WavefrontSensors.GroupedStaged2DPlan()
 function AdaptiveOpticsSim.sh_sensing_execution_plan(
     ::Backends.AcceleratorStyle{<:AMDGPU.ROCBackend},
     ::AdaptiveOpticsSim.ShackHartmannWFS,

--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -316,9 +316,89 @@ import .Detectors:
     write_output!
 include("calibration/modal_basis.jl")
 include("calibration/ncpa.jl")
-include("wfs/sensing_modes.jl")
-include("wfs/stage_contracts.jl")
-include("wfs/grouped.jl")
+include("wfs/wavefront_sensors.jl")
+
+# Concrete WFS families remain flat only until their ordered namespace gates.
+# Import the common owner's identities explicitly so every later method extends
+# one authoritative generic rather than creating a root-owned duplicate.
+import .WavefrontSensors:
+    AbstractGroupedAccumulationPlan,
+    AbstractWFS,
+    AbstractWFSMeasurementPath,
+    AcquiredObservationPath,
+    Diffractive,
+    DirectMeasurementPath,
+    Geometric,
+    GroupedDirectAccumulatePlan,
+    GroupedStackReducePlan,
+    GroupedStaged2DPlan,
+    IncidenceFluxNormalization,
+    MeanValidFluxNormalization,
+    SensingMode,
+    WFSMeasurement,
+    WFSMeasurementMetadata,
+    WFSNormalization,
+    WFSObservation,
+    WFSObservationMetadata,
+    WFSPreparationError,
+    _capture_counting_wfs!,
+    _require_counting_wfs_source,
+    _require_counting_wfs_spectral_match,
+    _require_declared_wfs_units,
+    _require_real_square_wfs_observation,
+    _require_wfs_storage_domain,
+    acquire_wfs_observation!,
+    accumulate_grouped_sources!,
+    apply_shift_wfs!,
+    camera_frame,
+    deterministic_frame_readout_gain,
+    estimate_wfs_measurement!,
+    form_wfs_optical_products!,
+    grouped_accumulation_plan,
+    grouped_stack_view,
+    grouped_staging_buffer,
+    measure!,
+    measurement_metadata,
+    measurement_storage,
+    measurement_units,
+    observation_metadata,
+    observation_storage,
+    observation_units,
+    prepare_runtime_wfs!,
+    prepare_wfs_acquisition,
+    prepare_wfs_estimation,
+    prepare_wfs_optical_formation,
+    reference_signal,
+    reduce_grouped_blocks_kernel!,
+    reduce_grouped_stack!,
+    sensing_mode,
+    slopes,
+    supports_camera_frame,
+    supports_detector_output,
+    supports_grouped_execution,
+    supports_prepared_runtime,
+    supports_reference_signal,
+    supports_stacked_sources,
+    supports_valid_subaperture_mask,
+    usable_wfs_normalization,
+    validate_wfs_acquisition_binding,
+    validate_wfs_estimation_binding,
+    validate_wfs_measurement,
+    validate_wfs_observation,
+    validate_wfs_observations,
+    validate_wfs_optical_formation_binding,
+    validate_wfs_optical_input,
+    validate_wfs_optical_products,
+    valid_subaperture_mask,
+    wfs_calibration_signature,
+    wfs_detector_image,
+    wfs_detector_incidence_scale,
+    wfs_incident_photon_irradiance,
+    wfs_measurement_path,
+    wfs_output_frame,
+    wfs_output_frame_prototype,
+    wfs_output_metadata
+
 include("wfs/calibration.jl")
 include("wfs/elongation.jl")
 include("wfs/subapertures.jl")
@@ -328,7 +408,6 @@ include("wfs/pyramid.jl")
 include("wfs/bioedge.jl")
 include("wfs/zernike.jl")
 include("wfs/curvature.jl")
-include("wfs/interface.jl")
 include("wfs/lift.jl")
 include("plant/plant.jl")
 include("calibration/interaction_matrix.jl")

--- a/src/core/errors.jl
+++ b/src/core/errors.jl
@@ -17,11 +17,4 @@ struct NumericalConditionError <: AdaptiveOpticsSimError
     msg::String
 end
 
-"""Prepared-contract violation at one semantic wavefront-sensor stage."""
-struct WFSPreparationError <: AdaptiveOpticsSimError
-    stage::Symbol
-    reason::Symbol
-    msg::String
-end
-
 Base.showerror(io::IO, e::AdaptiveOpticsSimError) = print(io, e.msg)

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -1,16 +1,2 @@
-"""
-Wavefront sensors implement `measure!(wfs, pupil[, src])` and
-`update_valid_mask!(wfs, pupil)`.
-
-Optional behavior such as detector-coupled measurement, runtime preparation,
-stacked-source support, and grouped execution is expressed through the
-capability queries documented in the runtime/control interface layer.
-"""
-abstract type AbstractWFS <: AbstractOpticalElement end
-
-function apply_shift_wfs!(::AbstractWFS; sx, sy)
-    throw(InvalidConfiguration("apply_shift_wfs! is not supported for this WFS"))
-end
-
 """Detectors implement capture!(det, psf; rng)."""
 abstract type AbstractDetector <: AbstractOpticalElement end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -7,8 +7,7 @@
 
 export AdaptiveOpticsSimError, InvalidConfiguration, DimensionMismatchError
 export UnsupportedAlgorithm, NumericalConditionError
-export WFSPreparationError
-export Backends, Optics, Detectors, Atmospheres, Plant
+export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Plant
 
 export FidelityProfile, ScientificProfile, FastProfile, default_fidelity_profile
 export runtime_rng, deterministic_reference_rng
@@ -16,16 +15,6 @@ export runtime_rng, deterministic_reference_rng
 export InversePolicy, ExactPseudoInverse, TSVDInverse, TikhonovInverse, default_modal_inverse_policy
 export KLBasis, ZernikeModalBasis
 
-export Diffractive, Geometric
-export WFSObservationMetadata, WFSMeasurementMetadata
-export WFSObservation, WFSMeasurement
-export observation_storage, observation_units, observation_metadata
-export measurement_storage, measurement_units, measurement_metadata
-export prepare_wfs_optical_formation, form_wfs_optical_products!
-export prepare_wfs_acquisition, acquire_wfs_observation!
-export prepare_wfs_estimation, estimate_wfs_measurement!
-export AbstractWFSMeasurementPath, AcquiredObservationPath
-export DirectMeasurementPath, wfs_measurement_path
 export ShackHartmannDirectFrontEnd, ShackHartmannOpticalFrontEnd
 export shack_hartmann_rate_map
 export PyramidOpticalFrontEnd, pyramid_rate_map
@@ -44,11 +33,7 @@ export SubapertureLayout, SubapertureCalibration
 export subaperture_layout, subaperture_calibration, slope_extraction_model
 export set_subaperture_calibration!
 export valid_subaperture_indices
-export MeanValidFluxNormalization, IncidenceFluxNormalization
-export measure!, pyramid_modulation_frame, pyramid_modulation_frame!
-export valid_subaperture_mask, camera_frame, wfs_detector_image
-export slopes, wfs_calibration_signature
-export prepare_runtime_wfs!
+export pyramid_modulation_frame, pyramid_modulation_frame!
 export shack_hartmann_detector_image, shack_hartmann_detector_image!
 export n_valid_subapertures
 export LiFT, PreparedLiFTForwardModel, LiFTObservation
@@ -82,8 +67,6 @@ export runtime_timing
 public controller_output, reset_controller!, supports_controller_reset
 public run_ensemble!, ensemble_members, execution_policy
 public ensemble_ownership_roots, init_ensemble_scheduler, execute_ensemble!
-public supports_prepared_runtime, supports_detector_output
-public supports_stacked_sources, supports_grouped_execution
 public init_execution_state
 
 export TomographyAtmosphereParams, LGSAsterismParams, LGSWFSParams

--- a/src/plant/plant.jl
+++ b/src/plant/plant.jl
@@ -201,9 +201,7 @@ import ..Atmospheres:
     validate_atmosphere_rendering
 
 import ..AdaptiveOpticsSim:
-    AcquiredObservationPath,
     AdaptiveOpticsSimError,
-    DirectMeasurementPath,
     InvalidConfiguration,
     PreparedBioEdgeOpticalBundleFormation,
     PreparedBioEdgeOpticalFormation,
@@ -211,14 +209,18 @@ import ..AdaptiveOpticsSim:
     PreparedPyramidOpticalFormation,
     PreparedShackHartmannOpticalBundleFormation,
     PreparedShackHartmannOpticalFormation,
+    runtime_rng,
+    splitmix64
+
+import ..WavefrontSensors:
+    AcquiredObservationPath,
+    DirectMeasurementPath,
     WFSMeasurement,
     WFSObservation,
     acquire_wfs_observation!,
     estimate_wfs_measurement!,
     form_wfs_optical_products!,
     measurement_storage,
-    runtime_rng,
-    splitmix64,
     validate_wfs_acquisition_binding,
     validate_wfs_estimation_binding,
     validate_wfs_measurement,

--- a/src/wfs/abstract_wfs.jl
+++ b/src/wfs/abstract_wfs.jl
@@ -1,0 +1,21 @@
+"""Prepared-contract violation at one semantic wavefront-sensor stage."""
+struct WFSPreparationError <: AdaptiveOpticsSimError
+    stage::Symbol
+    reason::Symbol
+    msg::String
+end
+
+"""
+Wavefront sensors implement `measure!(wfs, pupil[, source])` and may extend the
+prepared optical-formation, acquisition, and estimation protocols.
+
+Optional detector coupling, runtime preparation, stacked-source support, and
+grouped execution are expressed through capability queries rather than
+subtype-specific conditionals.
+"""
+abstract type AbstractWFS <: AbstractOpticalElement end
+
+function apply_shift_wfs!(::AbstractWFS; sx, sy)
+    throw(InvalidConfiguration(
+        "apply_shift_wfs! is not supported for this WFS"))
+end

--- a/src/wfs/api.jl
+++ b/src/wfs/api.jl
@@ -1,0 +1,17 @@
+export WFSPreparationError
+export Diffractive, Geometric
+export WFSObservationMetadata, WFSMeasurementMetadata
+export WFSObservation, WFSMeasurement
+export observation_storage, observation_units, observation_metadata
+export measurement_storage, measurement_units, measurement_metadata
+export prepare_wfs_optical_formation, form_wfs_optical_products!
+export prepare_wfs_acquisition, acquire_wfs_observation!
+export prepare_wfs_estimation, estimate_wfs_measurement!
+export AbstractWFSMeasurementPath, AcquiredObservationPath
+export DirectMeasurementPath, wfs_measurement_path
+export MeanValidFluxNormalization, IncidenceFluxNormalization
+export measure!, valid_subaperture_mask, camera_frame, wfs_detector_image
+export slopes, wfs_calibration_signature, prepare_runtime_wfs!
+
+public supports_prepared_runtime, supports_detector_output
+public supports_stacked_sources, supports_grouped_execution

--- a/src/wfs/bioedge.jl
+++ b/src/wfs/bioedge.jl
@@ -16,6 +16,8 @@ include("bioedge/stages.jl")
 @inline camera_frame(wfs::BioEdgeWFS{<:Diffractive}) =
     wfs.acquisition.state.camera_frame
 @inline camera_frame(::BioEdgeWFS{<:Geometric}) = nothing
+@inline wfs_calibration_signature(wfs::BioEdgeWFS) =
+    wfs.estimator.state.calibration_signature
 
 @inline wfs_output_frame_prototype(wfs::BioEdgeWFS{<:Diffractive},
     ::Nothing) = camera_frame(wfs)

--- a/src/wfs/curvature.jl
+++ b/src/wfs/curvature.jl
@@ -1031,6 +1031,8 @@ end
     wfs.estimator.state.reference_signal_2d
 @inline camera_frame(wfs::CurvatureWFS) =
     wfs.acquisition.state.camera_frame
+@inline wfs_calibration_signature(wfs::CurvatureWFS) =
+    wfs.estimator.state.calibration_signature
 
 @inline wfs_output_frame(wfs::CurvatureWFS, ::Nothing) = camera_frame(wfs)
 @inline wfs_output_frame(wfs::CurvatureWFS, det::AbstractDetector) = camera_frame(wfs)

--- a/src/wfs/interface.jl
+++ b/src/wfs/interface.jl
@@ -11,12 +11,20 @@
 
 Return the current exported 1-D signal vector for a wavefront sensor.
 
-For geometric and centroid-based sensors this is the slope vector. For sensors
-such as `ZernikeWFS` and `CurvatureWFS`, the maintained runtime contract still
-uses the `slopes` name even though the stored values represent normalized
-signal samples rather than geometric slopes.
+For geometric and centroid-based sensors this is the slope vector. Other
+families may use the maintained `slopes` contract for normalized signal
+samples that are not geometric slopes.
 """
 function slopes end
+
+"""
+    measure!(wfs, pupil[, source][, detector]; rng)
+
+Update `wfs` from a pupil-plane input and return its maintained measurement
+product. Concrete wavefront-sensor families define the supported source and
+detector combinations.
+"""
+function measure! end
 
 """
     valid_subaperture_mask(wfs::AbstractWFS)
@@ -43,16 +51,7 @@ Return the optical calibration signature currently bound to a wavefront
 sensor. This accessor intentionally hides the family-specific ownership of
 calibration state.
 """
-@inline wfs_calibration_signature(wfs::ShackHartmannWFS) =
-    wfs.calibration.signature
-@inline wfs_calibration_signature(wfs::PyramidWFS) =
-    wfs.estimator.state.calibration_signature
-@inline wfs_calibration_signature(wfs::BioEdgeWFS) =
-    wfs.estimator.state.calibration_signature
-@inline wfs_calibration_signature(wfs::ZernikeWFS) =
-    wfs.estimator.state.calibration_signature
-@inline wfs_calibration_signature(wfs::CurvatureWFS) =
-    wfs.estimator.state.calibration_signature
+function wfs_calibration_signature end
 
 """
     camera_frame(wfs::AbstractWFS)

--- a/src/wfs/pyramid.jl
+++ b/src/wfs/pyramid.jl
@@ -17,6 +17,8 @@ include("pyramid/stages.jl")
 @inline camera_frame(wfs::PyramidWFS{<:Diffractive}) =
     wfs.acquisition.state.camera_frame
 @inline camera_frame(::PyramidWFS{<:Geometric}) = nothing
+@inline wfs_calibration_signature(wfs::PyramidWFS) =
+    wfs.estimator.state.calibration_signature
 
 @inline wfs_output_frame_prototype(wfs::PyramidWFS{<:Diffractive},
     ::Nothing) = camera_frame(wfs)

--- a/src/wfs/shack_hartmann.jl
+++ b/src/wfs/shack_hartmann.jl
@@ -16,6 +16,8 @@ include("shack_hartmann/stages.jl")
 @inline valid_subaperture_mask(wfs::ShackHartmannWFS) =
     wfs.front_end.layout.valid_mask
 @inline reference_signal(wfs::ShackHartmannWFS) = wfs.calibration.reference_signal_2d
+@inline wfs_calibration_signature(wfs::ShackHartmannWFS) =
+    wfs.calibration.signature
 
 @kernel function shack_hartmann_detector_image_kernel!(image, spot_cube,
     n_sub::Int, n_axis_1::Int, n_axis_2::Int, gap::Int, gap_value)

--- a/src/wfs/wavefront_sensors.jl
+++ b/src/wfs/wavefront_sensors.jl
@@ -1,0 +1,88 @@
+"""
+    WavefrontSensors
+
+Canonical owner of composed wavefront-sensor contracts, typed observations
+and measurements, prepared stage protocols, and family-neutral execution
+capabilities. Reusable physical WFS components remain owned by `Optics`, while
+detector response and acquisition physics remain owned by `Detectors`.
+"""
+module WavefrontSensors
+
+using KernelAbstractions
+using Random
+
+import ..AdaptiveOpticsSim:
+    AdaptiveOpticsSimError,
+    AbstractDetector,
+    InvalidConfiguration
+
+import ..Backends:
+    AbstractArrayBackend,
+    AbstractComputeDevice,
+    AcceleratorStyle,
+    CPUBackend,
+    ExecutionStyle,
+    HostComputeDevice,
+    ScalarCPUStyle,
+    backend,
+    compute_device,
+    execution_style,
+    launch_kernel!
+
+import ..Optics:
+    AbstractCombinationPolicy,
+    AbstractOpticalElement,
+    AbstractOpticalNormalization,
+    AbstractOpticalPlaneKind,
+    AbstractOpticalProduct,
+    AbstractSource,
+    AbstractSpatialMeasure,
+    AbstractSpectralCoordinate,
+    Asterism,
+    CellIntegratedMeasure,
+    DetectorPlane,
+    ElectricField,
+    IncoherentIntensityAddition,
+    IntegratedSpectralChannel,
+    IntensityMap,
+    MonochromaticChannel,
+    OpticalPlaneMetadata,
+    OpticalProductBundle,
+    PhotonRateNormalization,
+    PupilFunction,
+    PupilPlane,
+    SpatialDensityMeasure,
+    photon_irradiance,
+    require_leaf_source,
+    validate_plane_storage,
+    wavelength
+
+import ..Detectors:
+    AbstractCountingDetector,
+    CCDSensor,
+    CMOSSensor,
+    Detector,
+    EMCCDSensor,
+    HgCdTeAvalancheArraySensor,
+    InGaAsSensor,
+    MKIDArrayDetector,
+    capture!,
+    counting_array,
+    counting_exposure_time,
+    counting_fill_factor,
+    counting_post_gain,
+    counting_qe,
+    counting_source_throughput,
+    effective_qe,
+    ensure_buffers!,
+    output_frame,
+    prepare_detector_acquisition
+
+include("abstract_wfs.jl")
+include("sensing_modes.jl")
+include("stage_contracts.jl")
+include("grouped.jl")
+include("interface.jl")
+include("api.jl")
+
+end # module WavefrontSensors

--- a/src/wfs/zernike.jl
+++ b/src/wfs/zernike.jl
@@ -791,6 +791,8 @@ end
     wfs.estimator.state.reference_signal_2d
 @inline camera_frame(wfs::ZernikeWFS) =
     wfs.acquisition.state.camera_frame
+@inline wfs_calibration_signature(wfs::ZernikeWFS) =
+    wfs.estimator.state.calibration_signature
 
 @inline wfs_output_frame(wfs::ZernikeWFS, ::Nothing) = camera_frame(wfs)
 @inline wfs_output_frame(wfs::ZernikeWFS, det::AbstractDetector) = camera_frame(wfs)

--- a/test/backend_optional_common.jl
+++ b/test/backend_optional_common.jl
@@ -3519,8 +3519,8 @@ function run_optional_backend_plan_checks(::Type{AdaptiveOpticsSim.Backends.AMDG
         model=LayeredFresnelAtmosphericPropagation(T=T),
         zero_padding=1,
         T=T)
-    @test AdaptiveOpticsSim.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(pyr.front_end.propagation.intensity), pyr) isa AdaptiveOpticsSim.GroupedStaged2DPlan
-    @test AdaptiveOpticsSim.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(bio.front_end.propagation.intensity), bio) isa AdaptiveOpticsSim.GroupedStaged2DPlan
+    @test AdaptiveOpticsSim.WavefrontSensors.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(pyr.front_end.propagation.intensity), pyr) isa AdaptiveOpticsSim.WavefrontSensors.GroupedStaged2DPlan
+    @test AdaptiveOpticsSim.WavefrontSensors.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(bio.front_end.propagation.intensity), bio) isa AdaptiveOpticsSim.WavefrontSensors.GroupedStaged2DPlan
     @test typeof(AdaptiveOpticsSim.sh_sensing_execution_plan(
         AdaptiveOpticsSim.Backends.execution_style(slopes(sh)), sh)) ===
         AdaptiveOpticsSim.ShackHartmannWFSRocmHostStatsPlan
@@ -3776,8 +3776,8 @@ function run_optional_backend_plan_checks(::Type{AdaptiveOpticsSim.Backends.CUDA
         model=LayeredFresnelAtmosphericPropagation(T=T),
         zero_padding=1,
         T=T)
-    @test AdaptiveOpticsSim.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(pyr.front_end.propagation.intensity), pyr) isa AdaptiveOpticsSim.GroupedStackReducePlan
-    @test AdaptiveOpticsSim.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(bio.front_end.propagation.intensity), bio) isa AdaptiveOpticsSim.GroupedStackReducePlan
+    @test AdaptiveOpticsSim.WavefrontSensors.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(pyr.front_end.propagation.intensity), pyr) isa AdaptiveOpticsSim.WavefrontSensors.GroupedStackReducePlan
+    @test AdaptiveOpticsSim.WavefrontSensors.grouped_accumulation_plan(AdaptiveOpticsSim.Backends.execution_style(bio.front_end.propagation.intensity), bio) isa AdaptiveOpticsSim.WavefrontSensors.GroupedStackReducePlan
     @test AdaptiveOpticsSim.sh_sensing_execution_plan(AdaptiveOpticsSim.Backends.execution_style(slopes(sh)), sh) isa AdaptiveOpticsSim.ShackHartmannWFSBatchedPlan
     @test AdaptiveOpticsSim.Detectors.detector_execution_plan(typeof(AdaptiveOpticsSim.Backends.execution_style(det.state.frame)), typeof(det)) isa AdaptiveOpticsSim.Detectors.DetectorDirectPlan
     @test AdaptiveOpticsSim.Backends.reduction_execution_plan(pyr.front_end.propagation.intensity) isa AdaptiveOpticsSim.Backends.DirectReductionPlan
@@ -3807,8 +3807,8 @@ function run_optional_backend_plan_checks(::Type{AdaptiveOpticsSim.Backends.CUDA
     measure!(gpu_sh, gpu_pupil, gpu_src, gpu_det; rng=MersenneTwister(3))
     cpu_export = Array(AdaptiveOpticsSim.sh_exported_spot_cube(cpu_sh))
     gpu_export = Array(AdaptiveOpticsSim.sh_exported_spot_cube(gpu_sh))
-    cpu_frame = Array(AdaptiveOpticsSim.wfs_output_frame(cpu_sh, cpu_det))
-    gpu_frame = Array(AdaptiveOpticsSim.wfs_output_frame(gpu_sh, gpu_det))
+    cpu_frame = Array(AdaptiveOpticsSim.WavefrontSensors.wfs_output_frame(cpu_sh, cpu_det))
+    gpu_frame = Array(AdaptiveOpticsSim.WavefrontSensors.wfs_output_frame(gpu_sh, gpu_det))
     @test size(gpu_export) == size(cpu_export)
     @test isapprox(gpu_export, cpu_export; rtol=1f-5, atol=1f-4)
     @test size(gpu_frame) == size(cpu_frame)

--- a/test/contracts/namespace_migration_state.toml
+++ b/test/contracts/namespace_migration_state.toml
@@ -2,15 +2,105 @@ schema_version = 1
 name = "namespace_migration_state"
 status = "maintained"
 authority = "namespace_authority.toml"
-current_gate = "NS-05"
+current_gate = "NS-06A"
 implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres"]
-partial_owners = []
+partial_owners = ["WavefrontSensors"]
 
 [owner_sources]
 Backends = "src/backends/api.jl"
 Optics = "src/optics/api.jl"
 Detectors = "src/detectors/api.jl"
 Atmospheres = "src/atmosphere/api.jl"
+
+[partial_owner_sources]
+WavefrontSensors = "src/wfs/api.jl"
+
+[partial_owner_bindings.WavefrontSensors]
+exports = [
+    "WFSPreparationError",
+    "Diffractive",
+    "Geometric",
+    "WFSObservationMetadata",
+    "WFSMeasurementMetadata",
+    "WFSObservation",
+    "WFSMeasurement",
+    "observation_storage",
+    "observation_units",
+    "observation_metadata",
+    "measurement_storage",
+    "measurement_units",
+    "measurement_metadata",
+    "prepare_wfs_optical_formation",
+    "form_wfs_optical_products!",
+    "prepare_wfs_acquisition",
+    "acquire_wfs_observation!",
+    "prepare_wfs_estimation",
+    "estimate_wfs_measurement!",
+    "AbstractWFSMeasurementPath",
+    "AcquiredObservationPath",
+    "DirectMeasurementPath",
+    "wfs_measurement_path",
+    "MeanValidFluxNormalization",
+    "IncidenceFluxNormalization",
+    "measure!",
+    "valid_subaperture_mask",
+    "camera_frame",
+    "wfs_detector_image",
+    "slopes",
+    "wfs_calibration_signature",
+    "prepare_runtime_wfs!",
+]
+public = [
+    "supports_prepared_runtime",
+    "supports_detector_output",
+    "supports_stacked_sources",
+    "supports_grouped_execution",
+]
+internal = [
+    "AbstractWFS",
+    "SensingMode",
+    "WFSNormalization",
+    "sensing_mode",
+    "apply_shift_wfs!",
+    "reference_signal",
+    "supports_valid_subaperture_mask",
+    "supports_reference_signal",
+    "supports_camera_frame",
+    "wfs_output_frame",
+    "wfs_output_frame_prototype",
+    "wfs_output_metadata",
+    "wfs_incident_photon_irradiance",
+    "wfs_detector_incidence_scale",
+    "deterministic_frame_readout_gain",
+    "usable_wfs_normalization",
+    "validate_wfs_observation",
+    "validate_wfs_observations",
+    "validate_wfs_measurement",
+    "validate_wfs_optical_input",
+    "validate_wfs_optical_products",
+    "validate_wfs_optical_formation_binding",
+    "validate_wfs_acquisition_binding",
+    "validate_wfs_estimation_binding",
+    "PreparedWFSDetectorAcquisition",
+    "PreparedWFSCountingAcquisition",
+    "PreparedWFSMultipleDetectorAcquisition",
+    "_require_declared_wfs_units",
+    "_require_wfs_storage_domain",
+    "_require_real_square_wfs_observation",
+    "_require_counting_wfs_source",
+    "_require_counting_wfs_spectral_match",
+    "_capture_counting_wfs!",
+    "AbstractGroupedAccumulationPlan",
+    "GroupedStackReducePlan",
+    "GroupedDirectAccumulatePlan",
+    "GroupedStaged2DPlan",
+    "grouped_accumulation_plan",
+    "accumulate_grouped_sources!",
+    "grouped_stack_view",
+    "grouped_staging_buffer",
+    "reduce_grouped_stack!",
+    "reduce_grouped_blocks_kernel!",
+]
 
 [baseline_divergence]
 root_surface = "src/exports.jl"

--- a/test/ka_cpu_matrix.jl
+++ b/test/ka_cpu_matrix.jl
@@ -415,18 +415,21 @@ end
         stack = reshape(collect(1.0:48.0), 4, 4, 3)
         scalar_group = Matrix{Float64}(undef, 4, 4)
         ka_group = similar(scalar_group)
-        AdaptiveOpticsSim.reduce_grouped_stack!(SCALAR_CPU_STYLE, scalar_group, stack, 3)
-        AdaptiveOpticsSim.reduce_grouped_stack!(KA_CPU_STYLE, ka_group, stack, 3)
+        AdaptiveOpticsSim.WavefrontSensors.reduce_grouped_stack!(
+            SCALAR_CPU_STYLE, scalar_group, stack, 3)
+        AdaptiveOpticsSim.WavefrontSensors.reduce_grouped_stack!(
+            KA_CPU_STYLE, ka_group, stack, 3)
         mark_ka_cpu_kernel!(:reduce_grouped_stack_kernel!)
         @test ka_group == scalar_group
 
         block_stack = reshape(collect(1.0:128.0), 4, 4, 8)
         block_out = zeros(Float64, 4, 4, 4)
-        AdaptiveOpticsSim.reduce_grouped_blocks!(KA_CPU_STYLE, block_out, block_stack, 4, 2)
+        AdaptiveOpticsSim.WavefrontSensors.reduce_grouped_blocks!(
+            KA_CPU_STYLE, block_out, block_stack, 4, 2)
         mark_ka_cpu_kernel!(:reduce_grouped_blocks_kernel!)
         @test block_out == block_stack[:, :, 1:4] .+ block_stack[:, :, 5:8]
 
-        @test size(AdaptiveOpticsSim.grouped_stack_view(stack, 2), 3) == 2
+        @test size(AdaptiveOpticsSim.WavefrontSensors.grouped_stack_view(stack, 2), 3) == 2
         grouped_tel = Telescope(resolution=8, diameter=8.0, central_obstruction=0.0)
         grouped_wfs = ShackHartmannWFS(grouped_tel; n_lenslets=2, mode=Diffractive(), n_pix_subap=2)
         grouped_sources = [1.0, 2.0, 3.0]
@@ -436,33 +439,37 @@ end
         end
         scalar_accum = zeros(Float64, 2, 2)
         scalar_stack = zeros(Float64, 2, 2, length(grouped_sources))
-        AdaptiveOpticsSim.accumulate_grouped_sources!(
-            AdaptiveOpticsSim.GroupedStackReducePlan(), SCALAR_CPU_STYLE, grouped_wfs,
+        AdaptiveOpticsSim.WavefrontSensors.accumulate_grouped_sources!(
+            AdaptiveOpticsSim.WavefrontSensors.GroupedStackReducePlan(),
+            SCALAR_CPU_STYLE, grouped_wfs,
             scalar_accum, scalar_stack, grouped_sources, fill_grouped_stage!, 2.0)
         @test scalar_accum == fill(12.0, 2, 2)
         ka_accum = zeros(Float64, 2, 2)
         ka_stack = zeros(Float64, 2, 2, length(grouped_sources))
-        AdaptiveOpticsSim.accumulate_grouped_sources!(
-            AdaptiveOpticsSim.GroupedStackReducePlan(), KA_CPU_STYLE, grouped_wfs,
+        AdaptiveOpticsSim.WavefrontSensors.accumulate_grouped_sources!(
+            AdaptiveOpticsSim.WavefrontSensors.GroupedStackReducePlan(),
+            KA_CPU_STYLE, grouped_wfs,
             ka_accum, ka_stack, grouped_sources, fill_grouped_stage!, 2.0)
         @test ka_accum == scalar_accum
         staged_scalar = zeros(Float64, 2, 2)
         staged_scalar_stack = zeros(Float64, 2, 2, length(grouped_sources))
-        AdaptiveOpticsSim.accumulate_grouped_sources!(
-            AdaptiveOpticsSim.GroupedStaged2DPlan(), SCALAR_CPU_STYLE, grouped_wfs,
+        AdaptiveOpticsSim.WavefrontSensors.accumulate_grouped_sources!(
+            AdaptiveOpticsSim.WavefrontSensors.GroupedStaged2DPlan(),
+            SCALAR_CPU_STYLE, grouped_wfs,
             staged_scalar, staged_scalar_stack, grouped_sources, fill_grouped_stage!, 3.0)
         @test staged_scalar == fill(18.0, 2, 2)
         staged_ka = zeros(Float64, 2, 2)
         staged_ka_stack = zeros(Float64, 2, 2, length(grouped_sources))
-        AdaptiveOpticsSim.accumulate_grouped_sources!(
-            AdaptiveOpticsSim.GroupedStaged2DPlan(), KA_CPU_STYLE, grouped_wfs,
+        AdaptiveOpticsSim.WavefrontSensors.accumulate_grouped_sources!(
+            AdaptiveOpticsSim.WavefrontSensors.GroupedStaged2DPlan(),
+            KA_CPU_STYLE, grouped_wfs,
             staged_ka, staged_ka_stack, grouped_sources, fill_grouped_stage!, 3.0)
         @test staged_ka == staged_scalar
         dispatch_accum = zeros(Float64, 2, 2)
         dispatch_stack = zeros(Float64, 2, 2, length(grouped_sources))
-        @test AdaptiveOpticsSim.grouped_accumulation_plan(KA_CPU_STYLE, grouped_wfs) isa
-              AdaptiveOpticsSim.GroupedStackReducePlan
-        AdaptiveOpticsSim.accumulate_grouped_sources!(
+        @test AdaptiveOpticsSim.WavefrontSensors.grouped_accumulation_plan(KA_CPU_STYLE, grouped_wfs) isa
+            AdaptiveOpticsSim.WavefrontSensors.GroupedStackReducePlan
+        AdaptiveOpticsSim.WavefrontSensors.accumulate_grouped_sources!(
             KA_CPU_STYLE, grouped_wfs, dispatch_accum, dispatch_stack,
             grouped_sources, fill_grouped_stage!, 1.0)
         @test dispatch_accum == fill(6.0, 2, 2)

--- a/test/ka_cpu_runtests.jl
+++ b/test/ka_cpu_runtests.jl
@@ -5,6 +5,7 @@ import AdaptiveOpticsSim.Optics: filter!
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
+using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using FFTW
@@ -55,6 +56,15 @@ for name in names(Atmospheres; all=true)
     if Base.isidentifier(s) && !startswith(s, "#") &&
             !isdefined(@__MODULE__, name)
         @eval const $(name) = getfield(Atmospheres, $(QuoteNode(name)))
+    end
+end
+
+for name in names(WavefrontSensors; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) =
+            getfield(WavefrontSensors, $(QuoteNode(name)))
     end
 end
 

--- a/test/reference_harness.jl
+++ b/test/reference_harness.jl
@@ -1501,10 +1501,11 @@ function compute_reference_actual_ka_cpu(case::ReferenceCase)
         n_sub = n_lenslets(wfs.front_end)
         sub = div(tel.params.resolution, n_sub)
         offset = n_sub * n_sub
-        slopes = similar(AdaptiveOpticsSim.slopes(wfs))
+        slopes = similar(AdaptiveOpticsSim.WavefrontSensors.slopes(wfs))
         style = AdaptiveOpticsSim.Backends.AcceleratorStyle(KernelAbstractions.CPU())
         AdaptiveOpticsSim._geometric_slopes!(style, slopes, pupil.opd,
-            AdaptiveOpticsSim.valid_subaperture_mask(wfs), sub, n_sub,
+            AdaptiveOpticsSim.WavefrontSensors.valid_subaperture_mask(wfs),
+            sub, n_sub,
             offset)
         return slopes
     end

--- a/test/runtests_head.jl
+++ b/test/runtests_head.jl
@@ -5,6 +5,7 @@ import AdaptiveOpticsSim.Optics: filter!
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
+using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra
@@ -68,6 +69,15 @@ for name in names(Atmospheres; all=true)
     if Base.isidentifier(s) && !startswith(s, "#") &&
             !isdefined(@__MODULE__, name)
         @eval const $(name) = getfield(Atmospheres, $(QuoteNode(name)))
+    end
+end
+
+for name in names(WavefrontSensors; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) =
+            getfield(WavefrontSensors, $(QuoteNode(name)))
     end
 end
 

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -278,7 +278,11 @@ end
     @test Base.isexported(AdaptiveOpticsSim, :BioEdgeWFS)
     @test Base.isexported(AdaptiveOpticsSim, :ZernikeWFS)
     @test Base.isexported(AdaptiveOpticsSim, :CurvatureWFS)
-    @test Base.isexported(AdaptiveOpticsSim, :prepare_runtime_wfs!)
+    @test !Base.isexported(AdaptiveOpticsSim, :prepare_runtime_wfs!)
+    @test !Base.ispublic(AdaptiveOpticsSim, :prepare_runtime_wfs!)
+    @test Base.isexported(WavefrontSensors, :prepare_runtime_wfs!)
+    @test parentmodule(WavefrontSensors.prepare_runtime_wfs!) ===
+        WavefrontSensors
     @test Base.isexported(AdaptiveOpticsSim, :subaperture_layout)
     @test !Base.isexported(AdaptiveOpticsSim, :compute_device)
     @test !Base.ispublic(AdaptiveOpticsSim, :AbstractComputeDevice)

--- a/test/testsets/namespace_authority.jl
+++ b/test/testsets/namespace_authority.jl
@@ -113,6 +113,8 @@ function adaptive_optics_sim_extension_hooks(path::AbstractString)
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Detectors\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
         "Atmospheres" =>
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Atmospheres\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
+        "WavefrontSensors" =>
+            r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?WavefrontSensors\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
     )
     owners = Dict{String,String}()
     for (owner, pattern) in patterns

--- a/test/testsets/pyramid_bioedge_and_lgs.jl
+++ b/test/testsets/pyramid_bioedge_and_lgs.jl
@@ -266,7 +266,8 @@ end
     AdaptiveOpticsSim._pyramid_slopes!(AdaptiveOpticsSim.Backends.ScalarCPUStyle(), invalid_slopes, ones(4, 4), falses(2, 2),
         2, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, (0, 0, 0, 0), (0, 0, 0, 0))
     @test all(iszero, invalid_slopes)
-    AdaptiveOpticsSim.apply_shift_wfs!(pyr_direct; sx=1.2, sy=-1.8)
+    AdaptiveOpticsSim.WavefrontSensors.apply_shift_wfs!(
+        pyr_direct; sx=1.2, sy=-1.8)
     @test pyr_direct.estimator.state.shift_x == (1, 1, 1, 1)
     @test pyr_direct.estimator.state.shift_y == (-2, -2, -2, -2)
     shift_x, shift_y = AdaptiveOpticsSim.pyramid_shift_components([0, 1, 2, 3], [3, 2, 1, 0])
@@ -1119,13 +1120,14 @@ end
 
     slopes = measure!(sh, pupil, src)
     @test all(isfinite, slopes)
-    meta = AdaptiveOpticsSim.wfs_output_metadata(sh)
+    meta = AdaptiveOpticsSim.WavefrontSensors.wfs_output_metadata(sh)
     @test meta.n_valid_subap == n_valid_subapertures(layout)
     @test meta.subap_pixels == layout.subap_pixels
     @test meta.calibrated
 
     dm = DeformableMirror(tel; n_act=5)
     imat = interaction_matrix(dm, sh, pupil, src; amplitude=1e-8)
-    @test size(imat.matrix, 1) == length(AdaptiveOpticsSim.slopes(sh))
+    @test size(imat.matrix, 1) ==
+        length(AdaptiveOpticsSim.WavefrontSensors.slopes(sh))
     @test size(imat.matrix, 2) == length(dm.state.coefs)
 end

--- a/test/testsets/wfs_common_and_parity.jl
+++ b/test/testsets/wfs_common_and_parity.jl
@@ -1,3 +1,73 @@
+struct CommonContractWFS <: WavefrontSensors.AbstractWFS end
+
+@testset "Common WavefrontSensors ownership" begin
+    for name in (
+        :WFSPreparationError,
+        :Diffractive,
+        :Geometric,
+        :WFSObservation,
+        :WFSMeasurement,
+        :prepare_wfs_optical_formation,
+        :form_wfs_optical_products!,
+        :prepare_wfs_acquisition,
+        :acquire_wfs_observation!,
+        :prepare_wfs_estimation,
+        :estimate_wfs_measurement!,
+        :measure!,
+        :slopes,
+    )
+        @test parentmodule(getfield(WavefrontSensors, name)) ===
+            WavefrontSensors
+        @test !Base.isexported(AdaptiveOpticsSim, name)
+        @test !Base.ispublic(AdaptiveOpticsSim, name)
+        @test getfield(AdaptiveOpticsSim, name) ===
+            getfield(WavefrontSensors, name)
+    end
+
+    for family in (
+        :ShackHartmannWFS,
+        :PyramidWFS,
+        :BioEdgeWFS,
+        :ZernikeWFS,
+        :CurvatureWFS,
+        :LiFT,
+    )
+        @test !isdefined(WavefrontSensors, family)
+    end
+
+    sensor = CommonContractWFS()
+    @test @inferred(WavefrontSensors.sensing_mode(sensor)) isa Diffractive
+    @test !(@inferred supports_prepared_runtime(sensor, nothing))
+    @test !(@inferred supports_stacked_sources(sensor, nothing))
+    @test !(@inferred supports_grouped_execution(sensor, nothing))
+    @test @inferred(valid_subaperture_mask(sensor)) === nothing
+    @test @inferred(camera_frame(sensor)) === nothing
+
+    observation = @inferred WFSObservation(zeros(Float32, 2, 3);
+        units=:electron_count, layout=:detector_frame)
+    measurement = @inferred WFSMeasurement(zeros(Float32, 4);
+        units=:radian, kind=:slope)
+    @test observation_metadata(observation).dimensions == (2, 3)
+    @test measurement_metadata(measurement).dimensions == (4,)
+    observation_storage(observation)
+    measurement_storage(measurement)
+    @test @allocated(observation_storage(observation)) == 0
+    @test @allocated(measurement_storage(measurement)) == 0
+
+    common_entry = read(joinpath(dirname(pathof(AdaptiveOpticsSim)), "wfs",
+        "wavefront_sensors.jl"), String)
+    for family_source in (
+        "shack_hartmann.jl",
+        "pyramid.jl",
+        "bioedge.jl",
+        "zernike.jl",
+        "curvature.jl",
+        "lift.jl",
+    )
+        @test !occursin("include(\"$family_source\")", common_entry)
+    end
+end
+
 @testset "OOPAO parity knobs" begin
     tel = Telescope(resolution=32, diameter=8.0, central_obstruction=0.0)
     pupil = PupilFunction(tel)

--- a/test/testsets/wfs_stage_contracts.jl
+++ b/test/testsets/wfs_stage_contracts.jl
@@ -779,11 +779,18 @@ end
     pupil) = AdaptiveOpticsSim.prepare_bioedge_sampling!(sensor, pupil)
 
 @testset "Prepared WFS stage products and protocols" begin
-    @test Base.isexported(AdaptiveOpticsSim, :WFSObservation)
-    @test Base.isexported(AdaptiveOpticsSim, :WFSMeasurement)
-    @test Base.isexported(AdaptiveOpticsSim, :prepare_wfs_optical_formation)
-    @test Base.isexported(AdaptiveOpticsSim, :acquire_wfs_observation!)
-    @test Base.isexported(AdaptiveOpticsSim, :DirectMeasurementPath)
+    @test !Base.isexported(AdaptiveOpticsSim, :WFSObservation)
+    @test !Base.isexported(AdaptiveOpticsSim, :WFSMeasurement)
+    @test !Base.isexported(AdaptiveOpticsSim, :prepare_wfs_optical_formation)
+    @test !Base.isexported(AdaptiveOpticsSim, :acquire_wfs_observation!)
+    @test !Base.isexported(AdaptiveOpticsSim, :DirectMeasurementPath)
+    @test Base.isexported(WavefrontSensors, :WFSObservation)
+    @test Base.isexported(WavefrontSensors, :WFSMeasurement)
+    @test Base.isexported(
+        WavefrontSensors, :prepare_wfs_optical_formation)
+    @test Base.isexported(
+        WavefrontSensors, :acquire_wfs_observation!)
+    @test Base.isexported(WavefrontSensors, :DirectMeasurementPath)
 
     scalar_observation = WFSObservation(Ref(1.0); units=:electron_count,
         layout=:scalar_channel)

--- a/test/wfs_stage_contract_fixtures.jl
+++ b/test/wfs_stage_contract_fixtures.jl
@@ -42,10 +42,10 @@ function _contract_require_optical_domains(input, output)
     return nothing
 end
 
-function AdaptiveOpticsSim.prepare_wfs_optical_formation(
+function WavefrontSensors.prepare_wfs_optical_formation(
     model::ContractRateModel, input, output::IntensityMap)
-    AdaptiveOpticsSim.validate_wfs_optical_input(input)
-    AdaptiveOpticsSim.validate_wfs_optical_products(output)
+    WavefrontSensors.validate_wfs_optical_input(input)
+    WavefrontSensors.validate_wfs_optical_products(output)
     output.metadata === model.output_metadata ||
         throw(WFSPreparationError(:optical_formation, :plane_metadata,
             "contract fixture output metadata does not match its model"))
@@ -82,7 +82,7 @@ end
     return nothing
 end
 
-function AdaptiveOpticsSim.form_wfs_optical_products!(output::IntensityMap,
+function WavefrontSensors.form_wfs_optical_products!(output::IntensityMap,
     input::PupilFunction, plan::ContractRatePlan)
     _contract_require_rate_binding(output, input, plan)
     scale = plan.model.scale
@@ -92,7 +92,7 @@ function AdaptiveOpticsSim.form_wfs_optical_products!(output::IntensityMap,
     return output
 end
 
-function AdaptiveOpticsSim.form_wfs_optical_products!(output::IntensityMap,
+function WavefrontSensors.form_wfs_optical_products!(output::IntensityMap,
     input::ElectricField, plan::ContractRatePlan)
     _contract_require_rate_binding(output, input, plan)
     scale = plan.model.scale
@@ -100,7 +100,7 @@ function AdaptiveOpticsSim.form_wfs_optical_products!(output::IntensityMap,
     return output
 end
 
-function AdaptiveOpticsSim.validate_wfs_optical_formation_binding(
+function WavefrontSensors.validate_wfs_optical_formation_binding(
     output::IntensityMap, input, plan::ContractRatePlan)
     _contract_require_rate_binding(output, input, plan)
     return nothing
@@ -135,10 +135,10 @@ function _contract_prepare_rate_plans(models::Tuple, input, outputs::Tuple)
             Base.tail(outputs))...)
 end
 
-function AdaptiveOpticsSim.prepare_wfs_optical_formation(
+function WavefrontSensors.prepare_wfs_optical_formation(
     model::ContractBundleRateModel, input, output::OpticalProductBundle)
-    AdaptiveOpticsSim.validate_wfs_optical_input(input)
-    AdaptiveOpticsSim.validate_wfs_optical_products(output)
+    WavefrontSensors.validate_wfs_optical_input(input)
+    WavefrontSensors.validate_wfs_optical_products(output)
     plans = _contract_prepare_rate_plans(model.models, input, output.products)
     return ContractBundleRatePlan(plans, input, output)
 end
@@ -152,7 +152,7 @@ end
         input)
 end
 
-function AdaptiveOpticsSim.form_wfs_optical_products!(
+function WavefrontSensors.form_wfs_optical_products!(
     output::OpticalProductBundle, input, plan::ContractBundleRatePlan)
     output.products === plan.output.products ||
         throw(WFSPreparationError(:optical_formation, :prepared_binding,
@@ -161,7 +161,7 @@ function AdaptiveOpticsSim.form_wfs_optical_products!(
     return output
 end
 
-function AdaptiveOpticsSim.validate_wfs_optical_formation_binding(
+function WavefrontSensors.validate_wfs_optical_formation_binding(
     output::OpticalProductBundle, input, plan::ContractBundleRatePlan)
     output.products === plan.output.products || throw(WFSPreparationError(
         :optical_formation, :prepared_binding,
@@ -169,7 +169,7 @@ function AdaptiveOpticsSim.validate_wfs_optical_formation_binding(
     @inbounds for index in eachindex(plan.plans)
         component_input = AdaptiveOpticsSim.four_pupil_bundle_input(input,
             index)
-        AdaptiveOpticsSim.validate_wfs_optical_formation_binding(
+        WavefrontSensors.validate_wfs_optical_formation_binding(
             output[index], component_input, plan.plans[index])
     end
     return nothing
@@ -293,10 +293,10 @@ end
     return _contract_require_unique_detectors(Base.tail(bindings))
 end
 
-function AdaptiveOpticsSim.prepare_wfs_acquisition(
+function WavefrontSensors.prepare_wfs_acquisition(
     model::ContractDetectorAcquisitionModel, optical_products, observations)
-    AdaptiveOpticsSim.validate_wfs_optical_products(optical_products)
-    AdaptiveOpticsSim.validate_wfs_observations(observations)
+    WavefrontSensors.validate_wfs_optical_products(optical_products)
+    WavefrontSensors.validate_wfs_observations(observations)
     _contract_require_unique_detectors(model.bindings)
     _contract_require_binding_inputs(model.bindings, optical_products)
     _contract_require_binding_outputs(model.bindings, observations)
@@ -380,7 +380,7 @@ end
     return _contract_capture_bindings!(Base.tail(bindings), Base.tail(rngs))
 end
 
-function AdaptiveOpticsSim.acquire_wfs_observation!(observations,
+function WavefrontSensors.acquire_wfs_observation!(observations,
     optical_products, plan::ContractDetectorAcquisitionPlan, rng)
     _contract_require_rng_arity(plan.bindings, rng)
     _contract_require_rng_types(rng)
@@ -391,7 +391,7 @@ function AdaptiveOpticsSim.acquire_wfs_observation!(observations,
     return observations
 end
 
-function AdaptiveOpticsSim.validate_wfs_acquisition_binding(observations,
+function WavefrontSensors.validate_wfs_acquisition_binding(observations,
     optical_products, plan::ContractDetectorAcquisitionPlan)
     _contract_require_binding_inputs(plan.bindings, optical_products)
     _contract_require_binding_outputs(plan.bindings, observations)
@@ -507,10 +507,11 @@ end
     measurement::WFSMeasurement) =
     _contract_require_reduction_numeric_type(input, measurement)
 
-function AdaptiveOpticsSim.prepare_wfs_estimation(model::ContractSumEstimator,
+function WavefrontSensors.prepare_wfs_estimation(
+    model::ContractSumEstimator,
     input, measurement::WFSMeasurement)
-    AdaptiveOpticsSim.validate_wfs_observations(input)
-    AdaptiveOpticsSim.validate_wfs_measurement(measurement)
+    WavefrontSensors.validate_wfs_observations(input)
+    WavefrontSensors.validate_wfs_measurement(measurement)
     _contract_require_measurement_semantics(model, measurement)
     _contract_require_cpu_reduction(measurement)
     _contract_require_measurement_domains(input, measurement)
@@ -572,7 +573,7 @@ end
     observations::Tuple) = _contract_write_tuple_sums!(storage,
     observations, 1)
 
-function AdaptiveOpticsSim.estimate_wfs_measurement!(
+function WavefrontSensors.estimate_wfs_measurement!(
     measurement::WFSMeasurement, input,
     plan::ContractSumEstimatorPlan)
     _contract_require_observation_storage(input, plan.input)
@@ -581,10 +582,10 @@ function AdaptiveOpticsSim.estimate_wfs_measurement!(
     return measurement
 end
 
-AdaptiveOpticsSim.wfs_measurement_path(::ContractSumEstimatorPlan) =
+WavefrontSensors.wfs_measurement_path(::ContractSumEstimatorPlan) =
     AcquiredObservationPath()
 
-function AdaptiveOpticsSim.validate_wfs_estimation_binding(
+function WavefrontSensors.validate_wfs_estimation_binding(
     measurement::WFSMeasurement, input, plan::ContractSumEstimatorPlan)
     _contract_require_observation_storage(input, plan.input)
     _contract_require_measurement_storage(measurement, plan.measurement)
@@ -601,10 +602,11 @@ struct ContractCopyEstimatorPlan{I,M}
     measurement::M
 end
 
-function AdaptiveOpticsSim.prepare_wfs_estimation(model::ContractCopyEstimator,
+function WavefrontSensors.prepare_wfs_estimation(
+    model::ContractCopyEstimator,
     input::WFSObservation, measurement::WFSMeasurement)
-    AdaptiveOpticsSim.validate_wfs_observation(input)
-    AdaptiveOpticsSim.validate_wfs_measurement(measurement)
+    WavefrontSensors.validate_wfs_observation(input)
+    WavefrontSensors.validate_wfs_measurement(measurement)
     _contract_require_measurement_semantics(model, measurement)
     input.metadata.dimensions == measurement.metadata.dimensions ||
         throw(WFSPreparationError(:estimation, :shape,
@@ -621,7 +623,7 @@ function AdaptiveOpticsSim.prepare_wfs_estimation(model::ContractCopyEstimator,
     return ContractCopyEstimatorPlan(input, measurement)
 end
 
-function AdaptiveOpticsSim.estimate_wfs_measurement!(
+function WavefrontSensors.estimate_wfs_measurement!(
     measurement::WFSMeasurement, input::WFSObservation,
     plan::ContractCopyEstimatorPlan)
     _contract_require_observation_storage(input, plan.input)
@@ -630,10 +632,10 @@ function AdaptiveOpticsSim.estimate_wfs_measurement!(
     return measurement
 end
 
-AdaptiveOpticsSim.wfs_measurement_path(::ContractCopyEstimatorPlan) =
+WavefrontSensors.wfs_measurement_path(::ContractCopyEstimatorPlan) =
     AcquiredObservationPath()
 
-function AdaptiveOpticsSim.validate_wfs_estimation_binding(
+function WavefrontSensors.validate_wfs_estimation_binding(
     measurement::WFSMeasurement, input, plan::ContractCopyEstimatorPlan)
     _contract_require_observation_storage(input, plan.input)
     _contract_require_measurement_storage(measurement, plan.measurement)
@@ -666,11 +668,11 @@ function _contract_require_direct_numeric_type(input,
     return nothing
 end
 
-function AdaptiveOpticsSim.prepare_wfs_estimation(
+function WavefrontSensors.prepare_wfs_estimation(
     model::ContractDirectEstimator, input,
     measurement::WFSMeasurement)
-    AdaptiveOpticsSim.validate_wfs_optical_input(input)
-    AdaptiveOpticsSim.validate_wfs_measurement(measurement)
+    WavefrontSensors.validate_wfs_optical_input(input)
+    WavefrontSensors.validate_wfs_measurement(measurement)
     _contract_require_measurement_semantics(model, measurement)
     _contract_require_cpu_reduction(measurement)
     _contract_require_measurement_domain(input, measurement)
@@ -700,7 +702,7 @@ end
     return nothing
 end
 
-function AdaptiveOpticsSim.estimate_wfs_measurement!(
+function WavefrontSensors.estimate_wfs_measurement!(
     measurement::WFSMeasurement, input::PupilFunction,
     plan::ContractDirectEstimatorPlan)
     _contract_require_direct_input(input, plan.input)
@@ -713,7 +715,7 @@ function AdaptiveOpticsSim.estimate_wfs_measurement!(
     return measurement
 end
 
-function AdaptiveOpticsSim.estimate_wfs_measurement!(
+function WavefrontSensors.estimate_wfs_measurement!(
     measurement::WFSMeasurement, input::ElectricField,
     plan::ContractDirectEstimatorPlan)
     _contract_require_direct_input(input, plan.input)
@@ -726,10 +728,10 @@ function AdaptiveOpticsSim.estimate_wfs_measurement!(
     return measurement
 end
 
-AdaptiveOpticsSim.wfs_measurement_path(::ContractDirectEstimatorPlan) =
+WavefrontSensors.wfs_measurement_path(::ContractDirectEstimatorPlan) =
     DirectMeasurementPath()
 
-function AdaptiveOpticsSim.validate_wfs_estimation_binding(
+function WavefrontSensors.validate_wfs_estimation_binding(
     measurement::WFSMeasurement, input, plan::ContractDirectEstimatorPlan)
     _contract_require_direct_input(input, plan.input)
     _contract_require_measurement_storage(measurement, plan.measurement)
@@ -746,11 +748,11 @@ struct ContractDirectCopyEstimatorPlan{I,M}
     measurement::M
 end
 
-function AdaptiveOpticsSim.prepare_wfs_estimation(
+function WavefrontSensors.prepare_wfs_estimation(
     model::ContractDirectCopyEstimator, input::ElectricField,
     measurement::WFSMeasurement)
-    AdaptiveOpticsSim.validate_wfs_optical_input(input)
-    AdaptiveOpticsSim.validate_wfs_measurement(measurement)
+    WavefrontSensors.validate_wfs_optical_input(input)
+    WavefrontSensors.validate_wfs_measurement(measurement)
     _contract_require_measurement_semantics(model, measurement)
     input.metadata.dimensions == measurement.metadata.dimensions ||
         throw(WFSPreparationError(:estimation, :shape,
@@ -765,7 +767,7 @@ function AdaptiveOpticsSim.prepare_wfs_estimation(
     return ContractDirectCopyEstimatorPlan(input, measurement)
 end
 
-function AdaptiveOpticsSim.estimate_wfs_measurement!(
+function WavefrontSensors.estimate_wfs_measurement!(
     measurement::WFSMeasurement, input::ElectricField,
     plan::ContractDirectCopyEstimatorPlan)
     _contract_require_direct_input(input, plan.input)
@@ -774,10 +776,11 @@ function AdaptiveOpticsSim.estimate_wfs_measurement!(
     return measurement
 end
 
-AdaptiveOpticsSim.wfs_measurement_path(::ContractDirectCopyEstimatorPlan) =
+WavefrontSensors.wfs_measurement_path(
+    ::ContractDirectCopyEstimatorPlan) =
     DirectMeasurementPath()
 
-function AdaptiveOpticsSim.validate_wfs_estimation_binding(
+function WavefrontSensors.validate_wfs_estimation_binding(
     measurement::WFSMeasurement, input, plan::ContractDirectCopyEstimatorPlan)
     _contract_require_direct_input(input, plan.input)
     _contract_require_measurement_storage(measurement, plan.measurement)
@@ -839,11 +842,11 @@ function _contract_require_packed_cell_measure(::AbstractSpatialMeasure)
         "packed contract acquisition requires cell-integrated photon rates"))
 end
 
-function AdaptiveOpticsSim.prepare_wfs_acquisition(
+function WavefrontSensors.prepare_wfs_acquisition(
     model::ContractPackedAcquisition, optical_products,
     observation::WFSObservation)
-    AdaptiveOpticsSim.validate_wfs_optical_products(optical_products)
-    AdaptiveOpticsSim.validate_wfs_observation(observation)
+    WavefrontSensors.validate_wfs_optical_products(optical_products)
+    WavefrontSensors.validate_wfs_observation(observation)
     isfinite(model.duration) && model.duration > zero(model.duration) ||
         throw(WFSPreparationError(:acquisition, :duration,
             "packed acquisition duration must be finite and positive"))
@@ -896,10 +899,10 @@ function AdaptiveOpticsSim.prepare_wfs_acquisition(
         (first_view, second_view))
 end
 
-function AdaptiveOpticsSim.acquire_wfs_observation!(
+function WavefrontSensors.acquire_wfs_observation!(
     observation::WFSObservation, optical_products,
     plan::ContractPackedAcquisitionPlan, rng)
-    AdaptiveOpticsSim.validate_wfs_acquisition_binding(observation,
+    WavefrontSensors.validate_wfs_acquisition_binding(observation,
         optical_products, plan)
     inputs = _contract_two_products(optical_products)
     first_view = first(plan.views)
@@ -913,7 +916,7 @@ function AdaptiveOpticsSim.acquire_wfs_observation!(
 end
 
 
-function AdaptiveOpticsSim.validate_wfs_acquisition_binding(
+function WavefrontSensors.validate_wfs_acquisition_binding(
     observation::WFSObservation, optical_products,
     plan::ContractPackedAcquisitionPlan)
     inputs = _contract_two_products(optical_products)


### PR DESCRIPTION
Closes #145
Tracker: #136

## What

- establish `AdaptiveOpticsSim.WavefrontSensors` as the authoritative owner of family-neutral WFS contracts
- move `AbstractWFS`, preparation errors, observations/measurements, prepared stage protocols, execution traits, measurement paths, normalization policies, and shared grouped-execution seams into that owner
- keep concrete Shack–Hartmann, Pyramid/BioEdge, Zernike/Curvature, and LiFT definitions in their existing family files for NS-06B through NS-06E
- update the plant, AMDGPU extension, examples, benchmarks, tests, and maintained guides to import or extend the canonical owner
- remove superseded root exports without compatibility forwarding

## Why

The common WFS protocol had no durable domain owner and was interleaved with concrete sensor implementations. This creates one extension-safe generic-function authority while preserving the staged family migration and the current numerical behavior.

## API impact

This is an intentional breaking namespace refactor. Common WFS vocabulary is imported from `AdaptiveOpticsSim.WavefrontSensors`; the root exports only the canonical `WavefrontSensors` module for this slice. Concrete family exports remain temporarily at root until their ordered namespace gates.

## Validation

- namespace authority and migration inventory: 2,806/2,806
- HIL inventory: 93/93
- characterization baselines: 92/92
- WFS common ownership and prepared-stage suites: pass
- all concrete WFS family suites and LiFT: pass
- interface conformance: 213/213
- detector suite: 827/827
- KernelAbstractions CPU matrix: 193/193
- Aqua/quality: 11/11
- full CPU closure: `Pkg.test()` passed
- final precompile and owner-identity smoke: passed

Optional CUDA/AMDGPU package smoke tests were unavailable in the temporary local `Pkg.test()` environment; repository CI and the NS-10 hardware closure gate retain accelerator validation.
