### PR TITLE
NS-07A: establish Calibration namespace owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ slopes = measure!(wfs, pupil, src)
 ### 3. Build a closed-loop AO model
 
 ```julia
+using AdaptiveOpticsSim.Calibration
+
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)
 imat = interaction_matrix(dm, wfs, PupilFunction(tel), src; amplitude=0.1)
 recon = ModalReconstructor(imat; gain=0.5)

--- a/benchmarks/benchmark_ad_experiments.jl
+++ b/benchmarks/benchmark_ad_experiments.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using BenchmarkTools
 
 function bench_misregistration_wfs_ad_probe()
@@ -10,23 +11,23 @@ function bench_misregistration_wfs_ad_probe()
     basis = modal_basis(dm, tel; n_modes=2).M2C[:, 1:2]
     fields = [:shift_x, :shift_y, :rotation_deg]
 
-    fd = AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    fd = Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis; n_mis_reg=length(fields), field_order=fields,
         sensitivity=:finite_difference)
-    ad = AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    ad = Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis; n_mis_reg=length(fields), field_order=fields)
     max_abs_error = maximum(abs, ad.meta.D .- fd.meta.D)
     @assert isapprox(ad.meta.D, fd.meta.D; rtol=2e-3, atol=1e-9)
 
-    AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis; n_mis_reg=length(fields), field_order=fields,
         sensitivity=:finite_difference)
-    AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis; n_mis_reg=length(fields), field_order=fields)
-    alloc_fd = @allocated AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    alloc_fd = @allocated Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis; n_mis_reg=length(fields), field_order=fields,
         sensitivity=:finite_difference)
-    alloc_ad = @allocated AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    alloc_ad = @allocated Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis; n_mis_reg=length(fields), field_order=fields)
 
     println("Misregistration WFS-path default AD")
@@ -35,10 +36,10 @@ function bench_misregistration_wfs_ad_probe()
     println("  AD allocations after warmup: $(alloc_ad) bytes")
     println("  FD allocations after warmup: $(alloc_fd) bytes")
     println("  AD benchmark:")
-    display(@benchmark AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    display(@benchmark Calibration.compute_meta_sensitivity_matrix(
         $tel, $dm, $wfs, $basis; n_mis_reg=$(length(fields)), field_order=$fields))
     println("  finite-difference benchmark:")
-    display(@benchmark AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    display(@benchmark Calibration.compute_meta_sensitivity_matrix(
         $tel, $dm, $wfs, $basis; n_mis_reg=$(length(fields)), field_order=$fields,
         sensitivity=:finite_difference))
 end

--- a/benchmarks/benchmark_control_operators.jl
+++ b/benchmarks/benchmark_control_operators.jl
@@ -1,5 +1,6 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 using Statistics

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using BenchmarkTools
 using Random
 

--- a/benchmarks/support/closed_loop_workload.jl
+++ b/benchmarks/support/closed_loop_workload.jl
@@ -1,5 +1,6 @@
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 
 mutable struct ClosedLoopWorkload{
     S,A,R,P,O,W,C,V,RNG,T,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,15 +15,15 @@ imported by `using AdaptiveOpticsSim`, optical-foundation vocabulary imported
 by `using AdaptiveOpticsSim.Optics`, backend vocabulary imported by
 `using AdaptiveOpticsSim.Backends`, conventional detector vocabulary imported
 by `using AdaptiveOpticsSim.Detectors`, atmosphere vocabulary imported by
-`using AdaptiveOpticsSim.Atmospheres`, the routine plant workflow imported by
+`using AdaptiveOpticsSim.Atmospheres`, calibration vocabulary imported by
+`using AdaptiveOpticsSim.Calibration`, the routine plant workflow imported by
 `using AdaptiveOpticsSim.Plant`, and stable qualified APIs addressed through
 their canonical modules. Qualified public names are maintained but do not
-enter the caller's ordinary namespace. The root package exports the
-`Backends`, `Optics`, `Atmospheres`, `Detectors`, and `Plant` modules, not
-compatibility exports for their moved contents.
+enter the caller's ordinary namespace. The root package exports the canonical
+modules, not compatibility exports for their moved contents.
 
 The breaking namespace migration is in progress. `Backends`, `Optics`,
-`Atmospheres`, and `Detectors` are complete. `Atmospheres` owns atmosphere
+`Atmospheres`, `Detectors`, and `Calibration` are complete. `Atmospheres` owns atmosphere
 models and state, source-direction rendering and batching, and
 atmosphere-coupled propagation. `Detectors` owns both conventional frame/area
 and counting/channel sensor APIs. `Optics` owns
@@ -31,6 +31,8 @@ apertures, telescopes, sources, optical products and
 metadata, pupil/field formation, backend-portable Fraunhofer and Fresnel
 propagation, direct imaging, sampled OPD, physical NCPA, controllable optics,
 deformable mirrors, spatial filtering, and reusable physical WFS components.
+`Calibration` owns inverse policies, interaction and control matrices, modal
+bases, model-derived NCPA synthesis, fitting, and calibration workflows.
 Bindings assigned to later domain owners remain at the root until their owner
 PR lands. The exact final root and domain allowlists are frozen in
 [`../test/contracts/namespace_authority.toml`](../test/contracts/namespace_authority.toml).
@@ -45,7 +47,8 @@ curated separately in [`../src/plant/api.jl`](../src/plant/api.jl), the
 conventional detector surface in
 [`../src/detectors/api.jl`](../src/detectors/api.jl), and the
 canonical backend surface in
-[`../src/backends/api.jl`](../src/backends/api.jl). The currently implemented
+[`../src/backends/api.jl`](../src/backends/api.jl). The calibration surface is
+curated in [`../src/calibration/api.jl`](../src/calibration/api.jl). The currently implemented
 optical surface is curated in
 [`../src/optics/api.jl`](../src/optics/api.jl), and the atmosphere surface in
 [`../src/atmosphere/api.jl`](../src/atmosphere/api.jl). Each owner PR must converge on
@@ -235,16 +238,16 @@ incompatible geometry revisions, backends, or devices.
 - Compatible intensity accumulation: `PreparedIncoherentSum`,
   `prepare_incoherent_sum`, `accumulate_intensity!`
 - Fields and general propagation: `FraunhoferPropagation` and
-  `FresnelPropagation`. Atmosphere-coupled propagation remains at the root
-  until the `Atmospheres` owner gate
+  `FresnelPropagation`. Atmosphere-coupled propagation is owned by
+  `AdaptiveOpticsSim.Atmospheres`
 - Sampled OPD and physical NCPA: `OPDMap` and `NCPA`. `NCPA(opd)` stores only
   the explicit backend-resident optical-path-difference map in metres.
   KL/Zernike/M2C basis selection, coefficient generation, and atmosphere- or
   DM-derived synthesis are calibration policy; synthesis returns an
   `Optics.NCPA` but the physical optic does not retain calibration provenance
 - Optical bases and registration: `ZernikeBasis`, `compute_zernike!`,
-  `Misregistration`, and `apply_misregistration`. Calibration-owned `KLBasis`
-  and `ZernikeModalBasis` remain at the root until the `Calibration` gate
+  `Misregistration`, and `apply_misregistration`. Import calibration-owned
+  `KLBasis` and `ZernikeModalBasis` from `AdaptiveOpticsSim.Calibration`
 - Spatial filtering: `SpatialFilter`, `CircularFilter`, `SquareFilter`,
   `FoucaultFilter`, `prepare_spatial_filter`, and `filter!`. Because Base also
   exports an unrelated collection operation named `filter!`, call
@@ -1347,19 +1350,25 @@ windowed, correlation, and matched-filter estimators remain future policies.
 
 ## Calibration And Reconstruction
 
+Import the maintained calibration surface explicitly:
+
+```julia
+using AdaptiveOpticsSim.Calibration
+```
+
 - Interaction/control matrices: `InteractionMatrix`, `interaction_matrix`,
-  `ControlMatrix`. Caller-owned calibration storage is available through the
-  qualified `AdaptiveOpticsSim.interaction_matrix!` API.
+  `ControlMatrix`. The caller-owned in-place seam is currently internal and
+  available as `AdaptiveOpticsSim.Calibration.interaction_matrix!`.
 - Modal bases: `ModalBasis`, `KLDMModes`, `KLHHtPSD`,
   `kl_modal_basis`, `modal_basis`, `basis_from_m2c`
 - AO calibration: `AOCalibration`, `ao_calibration`, `control_matrix`
 - Error and optical-gain calibration: `fitting_error`, `GainSensingCamera`,
   `calibrate!`, `compute_optical_gains!`
-- Misregistration identification uses the qualified
-  `AdaptiveOpticsSim.MetaSensitivity`,
-  `AdaptiveOpticsSim.compute_meta_sensitivity_matrix`,
-  `AdaptiveOpticsSim.estimate_misregistration`, `AdaptiveOpticsSim.SPRINT`,
-  and `AdaptiveOpticsSim.estimate!` APIs. `MetaSensitivity` is the structured
+- Misregistration identification is an experimental qualified workflow under
+  `AdaptiveOpticsSim.Calibration`, including `MetaSensitivity`,
+  `compute_meta_sensitivity_matrix`, `estimate_misregistration`, `SPRINT`,
+  and `estimate!`. These names are not yet marked as stable public API.
+  `MetaSensitivity` is the structured
   result: it retains the reference interaction matrix, sensitivity operator,
   finite-difference validation steps, and ordered parameter names
 - Structured configuration snapshots use qualified

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -818,7 +818,8 @@ per-step control path.
 
 For large calibration/control surfaces:
 
-- use `AdaptiveOpticsSim.interaction_matrix!` with caller-owned storage when
+- use `AdaptiveOpticsSim.Calibration.interaction_matrix!` with caller-owned
+  storage when
   the calibration matrix should live in a memory map, shared buffer, or
   backend-native allocation
 - use `FactorizedReconstructor` when a validated truncated SVD rank can bound

--- a/docs/julia-tutorial-mappings.md
+++ b/docs/julia-tutorial-mappings.md
@@ -57,6 +57,7 @@ The snippets below assume:
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 ```
 
 ### Image formation

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -80,7 +80,7 @@ function rather than introducing a second root function identity.
 
 The package is transitioning from the original flat root surface to real
 domain modules alongside the existing `Plant` module. `Backends`, `Optics`,
-`Atmospheres`, and `Detectors` are complete. The common `WavefrontSensors`
+`Atmospheres`, `Detectors`, and `Calibration` are complete. The common `WavefrontSensors`
 contracts are established; concrete WFS families are moving through their
 remaining ordered gates. `Atmospheres` owns atmosphere models and state,
 source-direction rendering and batching, and
@@ -89,8 +89,11 @@ conventional frame/area and counting/channel detector models and acquisition,
 with one shared detector type graph. `Optics` owns apertures, telescopes, sources, optical
 location/product metadata, pupil and field formation, general Fraunhofer and
 Fresnel propagation, direct imaging, sampled OPD, physical NCPA, controllable
-optics, and reusable physical WFS components. `Calibration`, `Control`,
-`Tomography`, and `Ensembles` follow in dependency order. The
+optics, and reusable physical WFS components. `Calibration` owns inverse
+policy, interaction/control matrices, modal basis construction, model-derived
+NCPA synthesis, fitting, optical-gain calibration, and registration
+identification. `Control`, `Tomography`, and `Ensembles` follow in dependency
+order. The
 authoritative pre-migration inventory, final exact API allowlists,
 extension-hook owners, and cross-module imports are frozen in
 [`../test/contracts/namespace_authority.toml`](../test/contracts/namespace_authority.toml).

--- a/docs/model-cookbook.md
+++ b/docs/model-cookbook.md
@@ -134,6 +134,7 @@ without HIL scheduling:
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)
 interaction = interaction_matrix(

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -57,10 +57,11 @@ The package is organized around a small set of modeling objects:
 
 Import optical vocabulary and reusable physical components with
 `using AdaptiveOpticsSim.Optics`; import sensing vocabulary with
-`using AdaptiveOpticsSim.WavefrontSensors`. The common WFS contracts and the
+`using AdaptiveOpticsSim.WavefrontSensors`; import calibration vocabulary with
+`using AdaptiveOpticsSim.Calibration`. The common WFS contracts and the
 complete Shack–Hartmann, Pyramid, BioEdge, Zernike, and Curvature families
-live in `WavefrontSensors`; calibration and control vocabulary moves as its
-ordered owner gate lands.
+live in `WavefrontSensors`; inverse policy, interaction/control matrices,
+modal bases, and model-derived NCPA synthesis live in `Calibration`.
 
 ## Three Execution Layers
 
@@ -612,6 +613,8 @@ Use this when you care about:
 ### Workflow 3: Closed-loop AO simulation
 
 ```julia
+using AdaptiveOpticsSim.Calibration
+
 rng = runtime_rng(0)
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)
 calibration_pupil = PupilFunction(tel)
@@ -833,13 +836,14 @@ helpers, use namespaced access. Examples:
 pupil = PupilFunction(tel)
 ws = AdaptiveOpticsSim.Workspace(pupil.opd, size(pupil.opd, 1);
     rng=deterministic_reference_rng(0))
-sprint = AdaptiveOpticsSim.SPRINT(tel, dm, wfs, basis)
+sprint = AdaptiveOpticsSim.Calibration.SPRINT(tel, dm, wfs, basis)
 ```
 
-On CPU, SPRINT uses ForwardDiff-backed DM misregistration sensitivity by
-default for grid-backed Gaussian mirrors. Use `sensitivity=:finite_difference`
-for validation runs, supported WFS-misregistration finite differences, or
-accelerator-backed arrays.
+SPRINT is currently an experimental, owner-qualified calibration workflow
+rather than marked stable public API. On CPU it uses ForwardDiff-backed DM
+misregistration sensitivity by default for grid-backed Gaussian mirrors. Use
+`sensitivity=:finite_difference` for validation runs, supported
+WFS-misregistration finite differences, or accelerator-backed arrays.
 
 `compute_meta_sensitivity_matrix` returns a structured `MetaSensitivity`, and
 `snapshot_config` returns an ordinary string-keyed dictionary. Core neither

--- a/examples/closed_loop/run_cl.jl
+++ b/examples/closed_loop/run_cl.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop/run_cl_first_stage.jl
+++ b/examples/closed_loop/run_cl_first_stage.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_from_phase_screens.jl
+++ b/examples/closed_loop/run_cl_from_phase_screens.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_long_push_pull.jl
+++ b/examples/closed_loop/run_cl_long_push_pull.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop/run_cl_sinusoidal_modulation.jl
+++ b/examples/closed_loop/run_cl_sinusoidal_modulation.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_two_stages.jl
+++ b/examples/closed_loop/run_cl_two_stages.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_two_stages_atm_change.jl
+++ b/examples/closed_loop/run_cl_two_stages_atm_change.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_zernike.jl
+++ b/examples/closed_loop/run_cl_zernike.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop_demo.jl
+++ b/examples/closed_loop_demo.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 

--- a/examples/support/subaru_ao188_simulation.jl
+++ b/examples/support/subaru_ao188_simulation.jl
@@ -6,12 +6,15 @@ using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 using Statistics
 
-import AdaptiveOpticsSim: runtime_timing, materialize_build,
+import AdaptiveOpticsSim: runtime_timing,
     bin2d!, init_execution_state
+import AdaptiveOpticsSim.Calibration: BuildBackend, CPUBuildBackend,
+    GPUArrayBuildBackend, NativeBuildBackend, materialize_build
 import AdaptiveOpticsSim.Backends: execution_style, synchronize_backend!
 import AdaptiveOpticsSim.Detectors: convert_noise, validate_noise
 import AdaptiveOpticsSim.WavefrontSensors: prepare_sampling!,
@@ -570,8 +573,8 @@ function _low_order_command_basis(dm::DeformableMirror, tel::Telescope, active_m
 end
 
 function _full_command_reconstructor(M2C_host::AbstractMatrix{T}, imat::InteractionMatrix{T};
-    gain::Real, policy::InversePolicy, inverse_build_backend::AdaptiveOpticsSim.BuildBackend,
-    materialize_backend::AdaptiveOpticsSim.BuildBackend, ref::AbstractMatrix{T}) where {T<:AbstractFloat}
+    gain::Real, policy::InversePolicy, inverse_build_backend::BuildBackend,
+    materialize_backend::BuildBackend, ref::AbstractMatrix{T}) where {T<:AbstractFloat}
     return MappedReconstructor(
         M2C_host,
         imat;
@@ -584,11 +587,11 @@ function _full_command_reconstructor(M2C_host::AbstractMatrix{T}, imat::Interact
 end
 
 function _auto_build_backend(backend::AbstractArrayBackend)
-    backend isa CPUBackend && return AdaptiveOpticsSim.NativeBuildBackend()
-    backend isa CUDABackend && return AdaptiveOpticsSim.GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.CUDABackendTag)
-    backend isa MetalBackend && return AdaptiveOpticsSim.GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.MetalBackendTag)
-    backend isa AMDGPUBackend && return AdaptiveOpticsSim.GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.AMDGPUBackendTag)
-    return AdaptiveOpticsSim.NativeBuildBackend()
+    backend isa CPUBackend && return NativeBuildBackend()
+    backend isa CUDABackend && return GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.CUDABackendTag)
+    backend isa MetalBackend && return GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.MetalBackendTag)
+    backend isa AMDGPUBackend && return GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.AMDGPUBackendTag)
+    return NativeBuildBackend()
 end
 
 function _ao188_calibration_objects(params::AO188SimulationParams{T}) where {T<:AbstractFloat}
@@ -686,9 +689,9 @@ function prepare_replay!(simulation::AO188Simulation)
 end
 
 function subaru_ao188_simulation(; params::AO188SimulationParams=AO188SimulationParams(),
-    backend::AbstractArrayBackend=CPUBackend(), build_backend::Union{Nothing,AdaptiveOpticsSim.BuildBackend}=nothing, rng=runtime_rng())
+    backend::AbstractArrayBackend=CPUBackend(), build_backend::Union{Nothing,BuildBackend}=nothing, rng=runtime_rng())
     resolved_materialize_backend = isnothing(build_backend) ? _auto_build_backend(backend) : build_backend
-    resolved_calibration_backend = isnothing(build_backend) && !(backend isa CPUBackend) ? AdaptiveOpticsSim.CPUBuildBackend() : resolved_materialize_backend
+    resolved_calibration_backend = isnothing(build_backend) && !(backend isa CPUBackend) ? CPUBuildBackend() : resolved_materialize_backend
     T = typeof(params.diameter)
     if params.resolution % params.low_order_resolution != 0
         throw(InvalidConfiguration("low_order_resolution must evenly divide the main telescope resolution"))
@@ -729,7 +732,7 @@ function subaru_ao188_simulation(; params::AO188SimulationParams=AO188Simulation
     calibration_low_dm = low_dm
     calibration_high_wfs = high_wfs
     calibration_low_wfs = low_wfs
-    if resolved_calibration_backend isa AdaptiveOpticsSim.CPUBuildBackend && !(backend isa CPUBackend)
+    if resolved_calibration_backend isa CPUBuildBackend && !(backend isa CPUBackend)
         calibration_tel, calibration_low_tel, calibration_src,
         calibration_dm, calibration_low_dm, calibration_high_wfs, calibration_low_wfs =
             _ao188_calibration_objects(params)

--- a/examples/tutorials/common.jl
+++ b/examples/tutorials/common.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 import AdaptiveOpticsSim.Optics: filter!
 using Logging
 using Random

--- a/examples/tutorials/sprint.jl
+++ b/examples/tutorials/sprint.jl
@@ -5,7 +5,7 @@ function main(; resolution::Int=16)
     dm = DeformableMirror(tel; n_act=3, influence_width=0.35)
     wfs = ShackHartmannWFS(tel; n_lenslets=2, mode=Geometric())
     basis = modal_basis(dm, tel; n_modes=3).M2C
-    sprint = AdaptiveOpticsSim.SPRINT(tel, dm, wfs, basis;
+    sprint = Calibration.SPRINT(tel, dm, wfs, basis;
         n_mis_reg=2, field_order=[:shift_x, :shift_y])
 
     injected = Misregistration(shift_x=5e-4, shift_y=-5e-4, T=Float64)
@@ -13,7 +13,7 @@ function main(; resolution::Int=16)
         misregistration=injected)
     calib_in = interaction_matrix(dm_in, wfs, PupilFunction(tel), basis;
         amplitude=1e-9).matrix
-    estimate = AdaptiveOpticsSim.estimate!(sprint, calib_in; precision=4)
+    estimate = Calibration.estimate!(sprint, calib_in; precision=4)
 
     @info "SPRINT tutorial complete" shift_x=estimate.shift_x shift_y=estimate.shift_y
     return (

--- a/ext/AdaptiveOpticsSimAMDGPUExt.jl
+++ b/ext/AdaptiveOpticsSimAMDGPUExt.jl
@@ -1,7 +1,7 @@
 module AdaptiveOpticsSimAMDGPUExt
 
 import AdaptiveOpticsSim
-import AdaptiveOpticsSim: Backends, WavefrontSensors
+import AdaptiveOpticsSim: Backends, Calibration, WavefrontSensors
 using AMDGPU
 using AbstractFFTs
 using KernelAbstractions
@@ -87,8 +87,12 @@ function Backends.execute_fft_plan!(buffer::AMDGPU.ROCArray, plan::AbstractFFTs.
     AMDGPU.synchronize()
     return buffer
 end
-AdaptiveOpticsSim.default_build_backend(::AMDGPU.ROCArray) = AdaptiveOpticsSim.GPUArrayBuildBackend(Backends.AMDGPUBackendTag)
-AdaptiveOpticsSim.prepare_build_matrix(::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag}, A::AbstractMatrix) = Matrix(A)
+Calibration.default_build_backend(::AMDGPU.ROCArray) =
+    Calibration.GPUArrayBuildBackend(Backends.AMDGPUBackendTag)
+Calibration.prepare_build_matrix(
+    ::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+    A::AbstractMatrix,
+) = Matrix(A)
 WavefrontSensors.grouped_accumulation_plan(
     ::Type{<:Backends.AcceleratorStyle{<:AMDGPU.ROCBackend}},
     ::Type{<:WavefrontSensors.PyramidWFS},
@@ -257,7 +261,7 @@ copy_dense_to_roc!(dest::AMDGPU.ROCArray, src::AbstractMatrix) = copyto!(dest, s
 function roc_svd(A::AMDGPU.ROCArray{T,2}) where {T<:AbstractFloat}
     F = copy(A)
     U, S, Vt = AMDGPU.rocSOLVER.gesvd!('S', 'S', F)
-    return (; U, S, Vt, s_host=AdaptiveOpticsSim.singular_values_host(S))
+    return (; U, S, Vt, s_host=Calibration.singular_values_host(S))
 end
 
 function roc_lu_solve!(A::AMDGPU.ROCArray{T,2}, B::AMDGPU.ROCArray{T,2}) where {T<:AbstractFloat}
@@ -300,10 +304,10 @@ SVD factors.
 `rocSOLVER.gesvd!` returns `Vt`, so the final matrix product is expressed with
 transpose flags rather than materialized transposes.
 """
-function pseudoinverse_from_roc_svd(backend::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+function pseudoinverse_from_roc_svd(backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
     U::AMDGPU.ROCArray{T,2}, S::AMDGPU.ROCArray{T,1}, Vt::AMDGPU.ROCArray{T,2},
     inv_s_host::AbstractVector{T}) where {T<:AbstractFloat}
-    inv_s = AdaptiveOpticsSim.materialize_build(backend, S, inv_s_host)
+    inv_s = Calibration.materialize_build(backend, S, inv_s_host)
     U_scaled = copy(U)
     U_scaled .*= reshape(inv_s, 1, :)
     # Mathematically this is V * U_scaled', but rocSOLVER returns Vt and the
@@ -311,20 +315,20 @@ function pseudoinverse_from_roc_svd(backend::AdaptiveOpticsSim.GPUArrayBuildBack
     return AMDGPU.rocBLAS.gemm('T', 'T', Vt, U_scaled)
 end
 
-function inverse_scaling_and_stats(::AdaptiveOpticsSim.ExactPseudoInverse, s_host::AbstractVector{T}) where {T<:AbstractFloat}
+function inverse_scaling_and_stats(::Calibration.ExactPseudoInverse, s_host::AbstractVector{T}) where {T<:AbstractFloat}
     inv_s_host = similar(s_host)
     @inbounds for i in eachindex(s_host)
         inv_s_host[i] = iszero(s_host[i]) ? zero(T) : inv(s_host[i])
     end
     effective_rank = count(!iszero, s_host)
     cond = effective_rank == 0 ? T(Inf) : s_host[begin] / s_host[effective_rank]
-    return inv_s_host, AdaptiveOpticsSim.InverseStats(s_host, cond, effective_rank, 0)
+    return inv_s_host, Calibration.InverseStats(s_host, cond, effective_rank, 0)
 end
 
-function inverse_scaling_and_stats(policy::AdaptiveOpticsSim.TSVDInverse, s_host::AbstractVector{T}) where {T<:AbstractFloat}
+function inverse_scaling_and_stats(policy::Calibration.TSVDInverse, s_host::AbstractVector{T}) where {T<:AbstractFloat}
     policy.n_trunc >= 0 || throw(AdaptiveOpticsSim.InvalidConfiguration("TSVD n_trunc must be >= 0"))
-    isempty(s_host) && return similar(s_host), AdaptiveOpticsSim.InverseStats(s_host, T(Inf), 0, 0)
-    cutoff = AdaptiveOpticsSim._inverse_cutoff(s_host, T(policy.rtol), T(policy.atol))
+    isempty(s_host) && return similar(s_host), Calibration.InverseStats(s_host, T(Inf), 0, 0)
+    cutoff = Calibration._inverse_cutoff(s_host, T(policy.rtol), T(policy.atol))
     rank_by_tol = count(>(cutoff), s_host)
     effective_rank = max(rank_by_tol - policy.n_trunc, 0)
     inv_s_host = similar(s_host)
@@ -333,50 +337,50 @@ function inverse_scaling_and_stats(policy::AdaptiveOpticsSim.TSVDInverse, s_host
         inv_s_host[i] = inv(s_host[i])
     end
     cond = effective_rank == 0 ? T(Inf) : s_host[begin] / s_host[effective_rank]
-    return inv_s_host, AdaptiveOpticsSim.InverseStats(s_host, cond, effective_rank, length(s_host) - effective_rank)
+    return inv_s_host, Calibration.InverseStats(s_host, cond, effective_rank, length(s_host) - effective_rank)
 end
 
-function inverse_scaling_and_stats(policy::AdaptiveOpticsSim.TikhonovInverse, s_host::AbstractVector{T}) where {T<:AbstractFloat}
+function inverse_scaling_and_stats(policy::Calibration.TikhonovInverse, s_host::AbstractVector{T}) where {T<:AbstractFloat}
     policy.lambda >= 0 || throw(AdaptiveOpticsSim.InvalidConfiguration("Tikhonov lambda must be >= 0"))
     inv_s_host = similar(s_host)
     λ2 = T(policy.lambda)^2
     @inbounds for i in eachindex(s_host)
         inv_s_host[i] = s_host[i] / (s_host[i]^2 + λ2)
     end
-    cutoff = AdaptiveOpticsSim._inverse_cutoff(s_host, T(policy.rtol), T(policy.atol))
+    cutoff = Calibration._inverse_cutoff(s_host, T(policy.rtol), T(policy.atol))
     effective_rank = count(>(cutoff), s_host)
     denom = max(isempty(s_host) ? zero(T) : s_host[end], T(policy.lambda))
     cond = (isempty(s_host) || iszero(denom)) ? T(Inf) : s_host[begin] / denom
-    return inv_s_host, AdaptiveOpticsSim.InverseStats(s_host, cond, effective_rank, 0)
+    return inv_s_host, Calibration.InverseStats(s_host, cond, effective_rank, 0)
 end
 
 function roc_inverse_operator(
-    backend::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+    backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
     A::AMDGPU.ROCArray{T,2},
-    policy::AdaptiveOpticsSim.InversePolicy,
+    policy::Calibration.InversePolicy,
 ) where {T<:AbstractFloat}
     svd_parts = roc_svd(A)
     inv_s_host, stats = inverse_scaling_and_stats(policy, svd_parts.s_host)
     if isempty(svd_parts.s_host)
-        empty_inverse = AdaptiveOpticsSim.materialize_build(backend, similar(A, T, size(A, 2), size(A, 1)))
+        empty_inverse = Calibration.materialize_build(backend, similar(A, T, size(A, 2), size(A, 1)))
         return empty_inverse, stats
     end
     M = pseudoinverse_from_roc_svd(backend, svd_parts.U, svd_parts.S, svd_parts.Vt, inv_s_host)
     return M, stats
 end
 
-function AdaptiveOpticsSim.inverse_operator(backend::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
-    A::AMDGPU.ROCArray{T,2}, ::AdaptiveOpticsSim.ExactPseudoInverse) where {T<:AbstractFloat}
-    return roc_inverse_operator(backend, A, AdaptiveOpticsSim.ExactPseudoInverse())
+function Calibration.inverse_operator(backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+    A::AMDGPU.ROCArray{T,2}, ::Calibration.ExactPseudoInverse) where {T<:AbstractFloat}
+    return roc_inverse_operator(backend, A, Calibration.ExactPseudoInverse())
 end
 
-function AdaptiveOpticsSim.inverse_operator(backend::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
-    A::AMDGPU.ROCArray{T,2}, policy::AdaptiveOpticsSim.TSVDInverse) where {T<:AbstractFloat}
+function Calibration.inverse_operator(backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+    A::AMDGPU.ROCArray{T,2}, policy::Calibration.TSVDInverse) where {T<:AbstractFloat}
     return roc_inverse_operator(backend, A, policy)
 end
 
-function AdaptiveOpticsSim.inverse_operator(backend::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
-    A::AMDGPU.ROCArray{T,2}, policy::AdaptiveOpticsSim.TikhonovInverse) where {T<:AbstractFloat}
+function Calibration.inverse_operator(backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+    A::AMDGPU.ROCArray{T,2}, policy::Calibration.TikhonovInverse) where {T<:AbstractFloat}
     return roc_inverse_operator(backend, A, policy)
 end
 
@@ -391,7 +395,7 @@ implementation falls back to LU so the higher-level algorithm remains robust on
 ill-conditioned runtime/calibration cases.
 """
 function AdaptiveOpticsSim.stable_hermitian_right_division(
-    _backend::AdaptiveOpticsSim.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
+    _backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
     rhs::AMDGPU.ROCArray{T,2},
     gram::AMDGPU.ROCArray{T,2},
 ) where {T<:AbstractFloat}

--- a/scripts/generate_lift_gsc_profile_artifact.jl
+++ b/scripts/generate_lift_gsc_profile_artifact.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using Logging
 using Random
 using TOML

--- a/scripts/gpu_builder_contract.jl
+++ b/scripts/gpu_builder_contract.jl
@@ -1,5 +1,6 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 
 function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBackendTag}
@@ -8,7 +9,7 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
     BackendArray === nothing && error("GPU backend $(B) is not available")
 
     T = Float32
-    build_backend = AdaptiveOpticsSim.GPUArrayBuildBackend(B)
+    build_backend = Calibration.GPUArrayBuildBackend(B)
 
     A = AdaptiveOpticsSim.Backends.backend_rand(B, T, 8, 4)
     imat = InteractionMatrix(A, T(0.1))
@@ -18,10 +19,11 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
 
     recon = ModalReconstructor(imat; build_backend=build_backend)
     @assert recon.reconstructor isa BackendArray
-    recon_cpu = ModalReconstructor(InteractionMatrix(cpu_A, T(0.1)); build_backend=AdaptiveOpticsSim.CPUBuildBackend())
+    recon_cpu = ModalReconstructor(InteractionMatrix(cpu_A, T(0.1));
+        build_backend=Calibration.CPUBuildBackend())
     slopes_modal = reshape(T.(1:8), 8)
     @assert isapprox(
-        Array(reconstruct(recon, AdaptiveOpticsSim.materialize_build(build_backend, slopes_modal))),
+        Array(reconstruct(recon, Calibration.materialize_build(build_backend, slopes_modal))),
         reconstruct(recon_cpu, slopes_modal);
         rtol=1f-5,
         atol=1f-6,
@@ -65,7 +67,8 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
         valid_actuators=trues(1, 1),
     )
     grid_mask = trues(1, 1)
-    imat_t = AdaptiveOpticsSim.materialize_build(build_backend, reshape(T[1.0, 0.5], 2, 1))
+    imat_t = Calibration.materialize_build(build_backend,
+        reshape(T[1.0, 0.5], 2, 1))
     imat_t_cpu = reshape(T[1.0, 0.5], 2, 1)
     noise = AdaptiveOpticsSim.RelativeSignalNoise(T(0.1))
 
@@ -95,10 +98,11 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
         tomo,
         dm;
         noise_model=noise,
-        build_backend=AdaptiveOpticsSim.CPUBuildBackend(),
+        build_backend=Calibration.CPUBuildBackend(),
     )
     slopes_tomo = T[0.25, -0.5]
-    slopes_tomo_tr_gpu = AdaptiveOpticsSim.materialize_build(build_backend, convert.(eltype(tr.reconstructor), slopes_tomo))
+    slopes_tomo_tr_gpu = Calibration.materialize_build(build_backend,
+        convert.(eltype(tr.reconstructor), slopes_tomo))
     @assert isapprox(
         Array(AdaptiveOpticsSim.reconstruct_wavefront(tr, slopes_tomo_tr_gpu)),
         AdaptiveOpticsSim.reconstruct_wavefront(tr_cpu, slopes_tomo);
@@ -134,10 +138,11 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
         tomo,
         dm;
         noise_model=noise,
-        build_backend=AdaptiveOpticsSim.CPUBuildBackend(),
+        build_backend=Calibration.CPUBuildBackend(),
     )
     slopes_tomo_mr = convert.(eltype(mr_cpu.reconstructor), slopes_tomo)
-    slopes_tomo_mr_gpu = AdaptiveOpticsSim.materialize_build(build_backend, slopes_tomo_mr)
+    slopes_tomo_mr_gpu = Calibration.materialize_build(build_backend,
+        slopes_tomo_mr)
     @assert isapprox(
         Array(AdaptiveOpticsSim.reconstruct_wavefront(mr, slopes_tomo_mr_gpu)),
         AdaptiveOpticsSim.reconstruct_wavefront(mr_cpu, slopes_tomo_mr);

--- a/scripts/gpu_profile_auto_correlation_cuda.jl
+++ b/scripts/gpu_profile_auto_correlation_cuda.jl
@@ -26,7 +26,7 @@ function _profile_case(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBacken
 
     policy = AdaptiveOpticsSim.Backends.default_gpu_precision_policy(B)
     T = AdaptiveOpticsSim.Backends.gpu_build_type(policy)
-    backend = AdaptiveOpticsSim.GPUArrayBuildBackend(B)
+    backend = AdaptiveOpticsSim.Calibration.GPUArrayBuildBackend(B)
 
     n_lenslet = 3
     n_lgs = 2
@@ -111,7 +111,8 @@ function _profile_case(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBacken
 
     cst, var_term, inv_L0 = AdaptiveOpticsSim._covariance_constants(r0, atmosphere.L0)
     block = AdaptiveOpticsSim._backend_array(B, T, n_valid, n_valid)
-    fractional_cn2_native = AdaptiveOpticsSim.materialize_build(backend, atmosphere.fractional_cn2)
+    fractional_cn2_native = AdaptiveOpticsSim.Calibration.materialize_build(
+        backend, atmosphere.fractional_cn2)
 
     t_selected = 0
     t_scatter = 0

--- a/scripts/gpu_profile_model_tomography_contract.jl
+++ b/scripts/gpu_profile_model_tomography_contract.jl
@@ -16,7 +16,7 @@ function run_gpu_model_tomography_profile(::Type{B}) where {B<:AdaptiveOpticsSim
     high_accuracy = AdaptiveOpticsSim.Backends.high_accuracy_gpu_precision_policy(B)
     TB = AdaptiveOpticsSim.Backends.gpu_build_type(policy)
     TH = AdaptiveOpticsSim.Backends.gpu_build_type(high_accuracy)
-    build_backend = AdaptiveOpticsSim.GPUArrayBuildBackend(B)
+    build_backend = AdaptiveOpticsSim.Calibration.GPUArrayBuildBackend(B)
 
     n_lenslet = 3
     n_lgs = 2

--- a/scripts/gpu_profile_model_tomography_phases_contract.jl
+++ b/scripts/gpu_profile_model_tomography_phases_contract.jl
@@ -17,7 +17,7 @@ function run_gpu_model_tomography_phase_profile(::Type{B}) where {B<:AdaptiveOpt
 
     policy = AdaptiveOpticsSim.Backends.default_gpu_precision_policy(B)
     TB = AdaptiveOpticsSim.Backends.gpu_build_type(policy)
-    build_backend = AdaptiveOpticsSim.GPUArrayBuildBackend(B)
+    build_backend = AdaptiveOpticsSim.Calibration.GPUArrayBuildBackend(B)
 
     n_lenslet = 3
     n_lgs = 2
@@ -95,19 +95,23 @@ function run_gpu_model_tomography_phase_profile(::Type{B}) where {B<:AdaptiveOpt
     end
 
     gamma_native, t_gamma_native = _time_phase() do
-        value = AdaptiveOpticsSim.materialize_build(build_backend, gamma, gamma)
+        value = AdaptiveOpticsSim.Calibration.materialize_build(
+            build_backend, gamma, gamma)
         _sync_backend!(value)
     end
     cxx_native, t_cxx_native = _time_phase() do
-        value = AdaptiveOpticsSim.materialize_build(build_backend, gamma_native, cxx)
+        value = AdaptiveOpticsSim.Calibration.materialize_build(
+            build_backend, gamma_native, cxx)
         _sync_backend!(value)
     end
     cox_native, t_cox_native = _time_phase() do
-        value = AdaptiveOpticsSim.materialize_build(build_backend, gamma_native, cox)
+        value = AdaptiveOpticsSim.Calibration.materialize_build(
+            build_backend, gamma_native, cox)
         _sync_backend!(value)
     end
     native_mask, t_mask_native = _time_phase() do
-        value = AdaptiveOpticsSim.materialize_build(build_backend, gamma_native, grid_mask)
+        value = AdaptiveOpticsSim.Calibration.materialize_build(
+            build_backend, gamma_native, grid_mask)
         _sync_backend!(value)
     end
 

--- a/scripts/gpu_smoke_contract.jl
+++ b/scripts/gpu_smoke_contract.jl
@@ -4,6 +4,7 @@ using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using LinearAlgebra
 using Random
 using Statistics
@@ -36,7 +37,7 @@ function record_gpu_smoke!(f::Function, failures::Vector{String}, name::Abstract
     return nothing
 end
 
-function prepared_gpu_field(tel::Telescope, src::AbstractSource;
+function prepared_gpu_field(tel::Telescope, src;
     zero_padding::Int, T::Type{<:AbstractFloat})
     wavefront = PupilFunction(tel; T=T)
     field = ElectricField(wavefront, src; zero_padding=zero_padding, T=T)
@@ -45,7 +46,7 @@ function prepared_gpu_field(tel::Telescope, src::AbstractSource;
     return (; wavefront, field, plan)
 end
 
-function gpu_direct_image(tel::Telescope, src::AbstractSource;
+function gpu_direct_image(tel::Telescope, src;
     zero_padding::Int, T::Type{<:AbstractFloat})
     pupil = PupilFunction(tel; T=T)
     prepared = prepare_direct_imaging(pupil, src; zero_padding=zero_padding)
@@ -101,14 +102,14 @@ function run_gpu_smoke_matrix(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GP
         field = prepared.field
         @assert field.values isa BackendArray
         intensity = similar(field.values, T)
-        intensity!(intensity, field)
+        Optics.intensity!(intensity, field)
         @assert intensity isa BackendArray
 
         amplitude = similar(prepared.wavefront.opd, T,
             tel.params.resolution, tel.params.resolution)
         fill!(amplitude, T(0.5))
-        apply_amplitude!(field, amplitude, prepared.plan)
-        intensity!(intensity, field)
+        Optics.apply_amplitude!(field, amplitude, prepared.plan)
+        Optics.intensity!(intensity, field)
         @assert intensity isa BackendArray
 
         prepared2 = prepared_gpu_field(tel, src; zero_padding=2, T=T)
@@ -172,9 +173,9 @@ function run_gpu_smoke_matrix(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GP
         support = BackendArray{Bool}(undef, 16, 16)
         weighted = BackendArray{Complex{T}}(undef, 16, 16)
         valid = BackendArray{Bool}(undef, 4, 4)
-        build_mask!(support, AnnularAperture(inner_radius=T(0.2), outer_radius=T(1), T=T); grid=default_mask_grid(support; T=T))
-        apply_mask!(support, SpiderMask(thickness=T(0.1), angle_rad=T(pi / 4), T=T); grid=default_mask_grid(support; T=T))
-        build_mask!(weighted, CircularAperture(radius=T(4), T=T); grid=pixel_mask_grid(weighted; T=T), inside=complex(T(inv(sqrt(2))), T(inv(sqrt(2)))))
+        build_mask!(support, AnnularAperture(inner_radius=T(0.2), outer_radius=T(1), T=T); grid=Optics.default_mask_grid(support; T=T))
+        apply_mask!(support, SpiderMask(thickness=T(0.1), angle_rad=T(pi / 4), T=T); grid=Optics.default_mask_grid(support; T=T))
+        build_mask!(weighted, CircularAperture(radius=T(4), T=T); grid=Optics.pixel_mask_grid(weighted; T=T), inside=complex(T(inv(sqrt(2))), T(inv(sqrt(2)))))
         build_mask!(valid, SubapertureGridMask(threshold=T(0.1), T=T), support)
         @assert support isa BackendArray
         @assert weighted isa BackendArray
@@ -389,21 +390,21 @@ function run_gpu_smoke_matrix(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GP
 
     record_gpu_smoke!(failures, "atmosphere_phase_helpers") do
         atm = KolmogorovAtmosphere(tel; r0=0.2, L0=25.0, T=T, backend=backend)
-        ws = PhaseStatsWorkspace(tel.params.resolution; T=T, backend=backend)
-        screen, psd = ft_phase_screen(atm, tel.params.resolution, tel.params.diameter / tel.params.resolution;
+        ws = Atmospheres.PhaseStatsWorkspace(tel.params.resolution; T=T, backend=backend)
+        screen, psd = Atmospheres.ft_phase_screen(atm, tel.params.resolution, tel.params.diameter / tel.params.resolution;
             rng=rng, ws=ws, return_psd=true)
-        sh_screen = ft_sh_phase_screen(atm, tel.params.resolution, tel.params.diameter / tel.params.resolution;
+        sh_screen = Atmospheres.ft_sh_phase_screen(atm, tel.params.resolution, tel.params.diameter / tel.params.resolution;
             rng=rng, ws=ws, subharmonics=true, n_levels=2, subharmonic_radius=1)
         rho = similar(atm.state.opd, T, 4, 4)
         copyto!(rho, reshape(T[0.0, 0.02, 0.05, 0.1, 0.15, 0.25, 0.4, 0.8, 1.2, 1.6, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0], 4, 4))
-        cov = phase_covariance(rho, atm)
+        cov = Atmospheres.phase_covariance(rho, atm)
         freqs = similar(atm.state.freqs, T, 4)
         copyto!(freqs, T[0.1, 0.2, 0.3, 0.4])
-        covmat = covariance_matrix(freqs, freqs, atm)
-        spectrum = phase_spectrum(freqs, atm)
+        covmat = Atmospheres.covariance_matrix(freqs, freqs, atm)
+        spectrum = Atmospheres.phase_spectrum(freqs, atm)
         freq_grid = similar(atm.state.opd, T, 2, 2)
         copyto!(freq_grid, reshape(T[0.1, 0.2, 0.3, 0.4], 2, 2))
-        spectrum_grid = phase_spectrum(freq_grid, atm)
+        spectrum_grid = Atmospheres.phase_spectrum(freq_grid, atm)
         @assert screen isa BackendArray
         @assert psd isa BackendArray
         @assert sh_screen isa BackendArray
@@ -411,8 +412,8 @@ function run_gpu_smoke_matrix(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GP
         @assert covmat isa BackendArray
         @assert spectrum isa BackendArray
         @assert spectrum_grid isa BackendArray
-        cov_ref = phase_covariance(Array(rho), atm)
-        covmat_ref = covariance_matrix(Array(freqs), Array(freqs), atm)
+        cov_ref = Atmospheres.phase_covariance(Array(rho), atm)
+        covmat_ref = Atmospheres.covariance_matrix(Array(freqs), Array(freqs), atm)
         cov_rel = maximum(abs.(Array(cov) .- cov_ref)) / maximum(abs.(cov_ref))
         covmat_rel = maximum(abs.(Array(covmat) .- covmat_ref)) / maximum(abs.(covmat_ref))
         @assert cov_rel < 5e-4

--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -119,7 +119,6 @@ import .Backends:
     use_host_build_algebra,
     write_integer_output!
 
-include("core/inverse_policies.jl")
 include("core/utils.jl")
 
 # Configuration serialization remains a root-owned cross-domain seam. Declare
@@ -314,8 +313,6 @@ import .Detectors:
     validate_frame_response_model,
     validate_up_the_ramp_schedule,
     write_output!
-include("calibration/modal_basis.jl")
-include("calibration/ncpa.jl")
 include("wfs/wavefront_sensors.jl")
 
 # WFS families move through ordered namespace gates. Import common identities
@@ -423,15 +420,34 @@ import .WavefrontSensors:
     wfs_output_metadata
 
 include("plant/plant.jl")
-include("calibration/interaction_matrix.jl")
+include("calibration/calibration.jl")
+
+# Control and tomography still await their own namespace gates. Import only
+# the calibration identities their flat implementations consume; these are
+# package-internal composition bindings, not root exports or public API.
+import .Calibration:
+    BuildBackend,
+    CPUBuildBackend,
+    GPUArrayBuildBackend,
+    InteractionMatrix,
+    InversePolicy,
+    NativeBuildBackend,
+    default_build_backend,
+    default_modal_inverse_policy,
+    default_runtime_calibration_build_backend,
+    condition_number,
+    effective_rank,
+    inverse_factorization,
+    inverse_operator,
+    inverse_policy,
+    materialize_build,
+    materialize_runtime_build_result,
+    prepare_build_matrix,
+    singular_values,
+    truncation_count
+
 include("control/controller.jl")
 include("control/reconstructors.jl")
-include("calibration/control_matrix.jl")
-include("calibration/fitting_error.jl")
-include("calibration/ao_calibration.jl")
-include("calibration/gain_sensing_camera.jl")
-include("calibration/misregistration_identification.jl")
-include("calibration/ad_sensitivities.jl")
 include("control/ensemble.jl")
 include("tomography/parameters.jl")
 include("tomography/geometry.jl")

--- a/src/atmosphere/atmospheres.jl
+++ b/src/atmosphere/atmospheres.jl
@@ -23,10 +23,8 @@ import ..AdaptiveOpticsSim:
     UnsupportedAlgorithm,
     _scaled_kv56_scalar,
     atmosphere_profile,
-    default_build_backend,
     default_fidelity_profile,
-    fftfreq!,
-    materialize_build
+    fftfreq!
 
 import ..Backends:
     AbstractArrayBackend,

--- a/src/atmosphere/infinite_screen.jl
+++ b/src/atmosphere/infinite_screen.jl
@@ -1,3 +1,13 @@
+@inline function _copy_atmosphere_state!(out::AbstractArray, data::AbstractArray)
+    copyto!(out, data)
+    return out
+end
+
+@inline function _copy_atmosphere_state(ref::AbstractArray, data::AbstractArray)
+    out = similar(ref, eltype(data), size(data)...)
+    return _copy_atmosphere_state!(out, data)
+end
+
 @kernel function gather_stencil_data_kernel!(dest, screen, coords, n::Int)
     k = @index(Global, Linear)
     if k <= n
@@ -509,7 +519,6 @@ function InfinitePhaseScreen(tel::Telescope;
     screen = backend_array{T}(undef, stencil_size, stencil_size)
     screen_scratch = backend_array{T}(undef, stencil_size, stencil_size)
     extract_buffer = backend_array{T}(undef, tel.params.resolution, tel.params.resolution)
-    build_backend = default_build_backend(screen)
     fill!(screen, zero(T))
     fill!(screen_scratch, zero(T))
     fill!(extract_buffer, zero(T))
@@ -517,19 +526,19 @@ function InfinitePhaseScreen(tel::Telescope;
         screen,
         screen_scratch,
         extract_buffer,
-        materialize_build(build_backend, backend_array{T}(undef, size(column_positive.operator.predictor, 2)),
+        _copy_atmosphere_state!(backend_array{T}(undef, size(column_positive.operator.predictor, 2)),
             Vector{T}(undef, size(column_positive.operator.predictor, 2))),
-        materialize_build(build_backend, backend_array{T}(undef, size(column_positive.operator.predictor, 1)),
+        _copy_atmosphere_state!(backend_array{T}(undef, size(column_positive.operator.predictor, 1)),
             Vector{T}(undef, size(column_positive.operator.predictor, 1))),
-        materialize_build(build_backend, backend_array{T}(undef, size(column_positive.operator.residual_factor, 2)),
+        _copy_atmosphere_state!(backend_array{T}(undef, size(column_positive.operator.residual_factor, 2)),
             Vector{T}(undef, size(column_positive.operator.residual_factor, 2))),
-        materialize_build(build_backend, backend_array{Int}(undef, size(column_positive.stencil.stencil_coords)...),
+        _copy_atmosphere_state!(backend_array{Int}(undef, size(column_positive.stencil.stencil_coords)...),
             column_positive.stencil.stencil_coords),
-        materialize_build(build_backend, backend_array{Int}(undef, size(column_negative.stencil.stencil_coords)...),
+        _copy_atmosphere_state!(backend_array{Int}(undef, size(column_negative.stencil.stencil_coords)...),
             column_negative.stencil.stencil_coords),
-        materialize_build(build_backend, backend_array{Int}(undef, size(row_positive.stencil.stencil_coords)...),
+        _copy_atmosphere_state!(backend_array{Int}(undef, size(row_positive.stencil.stencil_coords)...),
             row_positive.stencil.stencil_coords),
-        materialize_build(build_backend, backend_array{Int}(undef, size(row_negative.stencil.stencil_coords)...),
+        _copy_atmosphere_state!(backend_array{Int}(undef, size(row_negative.stencil.stencil_coords)...),
             row_negative.stencil.stencil_coords),
         InfiniteBoundaryModel(
             InfiniteBoundaryStencil(
@@ -541,15 +550,14 @@ function InfinitePhaseScreen(tel::Telescope;
                 column_positive.stencil.side,
             ),
             InfiniteBoundaryOperator(
-                materialize_build(build_backend, screen, column_positive.operator.predictor),
-                materialize_build(build_backend, screen, column_positive.operator.residual_factor),
-                materialize_build(build_backend, screen, column_positive.operator.cov_zz),
-                materialize_build(build_backend, screen, column_positive.operator.cov_xx),
-                materialize_build(build_backend, screen, column_positive.operator.cov_xz),
-                materialize_build(build_backend, screen, column_positive.operator.cov_zx),
-                materialize_build(build_backend, screen, column_positive.operator.residual_covariance),
-                materialize_build(build_backend, Vector{T}(undef, length(column_positive.operator.singular_values)),
-                    column_positive.operator.singular_values),
+                _copy_atmosphere_state(screen, column_positive.operator.predictor),
+                _copy_atmosphere_state(screen, column_positive.operator.residual_factor),
+                _copy_atmosphere_state(screen, column_positive.operator.cov_zz),
+                _copy_atmosphere_state(screen, column_positive.operator.cov_xx),
+                _copy_atmosphere_state(screen, column_positive.operator.cov_xz),
+                _copy_atmosphere_state(screen, column_positive.operator.cov_zx),
+                _copy_atmosphere_state(screen, column_positive.operator.residual_covariance),
+                _copy_atmosphere_state(screen, column_positive.operator.singular_values),
                 T(column_positive.operator.condition_ratio),
                 column_positive.operator.orientation,
                 column_positive.operator.side,
@@ -565,15 +573,14 @@ function InfinitePhaseScreen(tel::Telescope;
                 column_negative.stencil.side,
             ),
             InfiniteBoundaryOperator(
-                materialize_build(build_backend, screen, column_negative.operator.predictor),
-                materialize_build(build_backend, screen, column_negative.operator.residual_factor),
-                materialize_build(build_backend, screen, column_negative.operator.cov_zz),
-                materialize_build(build_backend, screen, column_negative.operator.cov_xx),
-                materialize_build(build_backend, screen, column_negative.operator.cov_xz),
-                materialize_build(build_backend, screen, column_negative.operator.cov_zx),
-                materialize_build(build_backend, screen, column_negative.operator.residual_covariance),
-                materialize_build(build_backend, Vector{T}(undef, length(column_negative.operator.singular_values)),
-                    column_negative.operator.singular_values),
+                _copy_atmosphere_state(screen, column_negative.operator.predictor),
+                _copy_atmosphere_state(screen, column_negative.operator.residual_factor),
+                _copy_atmosphere_state(screen, column_negative.operator.cov_zz),
+                _copy_atmosphere_state(screen, column_negative.operator.cov_xx),
+                _copy_atmosphere_state(screen, column_negative.operator.cov_xz),
+                _copy_atmosphere_state(screen, column_negative.operator.cov_zx),
+                _copy_atmosphere_state(screen, column_negative.operator.residual_covariance),
+                _copy_atmosphere_state(screen, column_negative.operator.singular_values),
                 T(column_negative.operator.condition_ratio),
                 column_negative.operator.orientation,
                 column_negative.operator.side,
@@ -589,15 +596,14 @@ function InfinitePhaseScreen(tel::Telescope;
                 row_positive.stencil.side,
             ),
             InfiniteBoundaryOperator(
-                materialize_build(build_backend, screen, row_positive.operator.predictor),
-                materialize_build(build_backend, screen, row_positive.operator.residual_factor),
-                materialize_build(build_backend, screen, row_positive.operator.cov_zz),
-                materialize_build(build_backend, screen, row_positive.operator.cov_xx),
-                materialize_build(build_backend, screen, row_positive.operator.cov_xz),
-                materialize_build(build_backend, screen, row_positive.operator.cov_zx),
-                materialize_build(build_backend, screen, row_positive.operator.residual_covariance),
-                materialize_build(build_backend, Vector{T}(undef, length(row_positive.operator.singular_values)),
-                    row_positive.operator.singular_values),
+                _copy_atmosphere_state(screen, row_positive.operator.predictor),
+                _copy_atmosphere_state(screen, row_positive.operator.residual_factor),
+                _copy_atmosphere_state(screen, row_positive.operator.cov_zz),
+                _copy_atmosphere_state(screen, row_positive.operator.cov_xx),
+                _copy_atmosphere_state(screen, row_positive.operator.cov_xz),
+                _copy_atmosphere_state(screen, row_positive.operator.cov_zx),
+                _copy_atmosphere_state(screen, row_positive.operator.residual_covariance),
+                _copy_atmosphere_state(screen, row_positive.operator.singular_values),
                 T(row_positive.operator.condition_ratio),
                 row_positive.operator.orientation,
                 row_positive.operator.side,
@@ -613,15 +619,14 @@ function InfinitePhaseScreen(tel::Telescope;
                 row_negative.stencil.side,
             ),
             InfiniteBoundaryOperator(
-                materialize_build(build_backend, screen, row_negative.operator.predictor),
-                materialize_build(build_backend, screen, row_negative.operator.residual_factor),
-                materialize_build(build_backend, screen, row_negative.operator.cov_zz),
-                materialize_build(build_backend, screen, row_negative.operator.cov_xx),
-                materialize_build(build_backend, screen, row_negative.operator.cov_xz),
-                materialize_build(build_backend, screen, row_negative.operator.cov_zx),
-                materialize_build(build_backend, screen, row_negative.operator.residual_covariance),
-                materialize_build(build_backend, Vector{T}(undef, length(row_negative.operator.singular_values)),
-                    row_negative.operator.singular_values),
+                _copy_atmosphere_state(screen, row_negative.operator.predictor),
+                _copy_atmosphere_state(screen, row_negative.operator.residual_factor),
+                _copy_atmosphere_state(screen, row_negative.operator.cov_zz),
+                _copy_atmosphere_state(screen, row_negative.operator.cov_xx),
+                _copy_atmosphere_state(screen, row_negative.operator.cov_xz),
+                _copy_atmosphere_state(screen, row_negative.operator.cov_zx),
+                _copy_atmosphere_state(screen, row_negative.operator.residual_covariance),
+                _copy_atmosphere_state(screen, row_negative.operator.singular_values),
                 T(row_negative.operator.condition_ratio),
                 row_negative.operator.orientation,
                 row_negative.operator.side,

--- a/src/calibration/api.jl
+++ b/src/calibration/api.jl
@@ -1,0 +1,10 @@
+export InversePolicy, ExactPseudoInverse, TSVDInverse, TikhonovInverse
+export default_modal_inverse_policy
+export KLBasis, ZernikeModalBasis
+export InteractionMatrix, interaction_matrix
+export ControlMatrix
+export ModalBasis, KLDMModes, KLHHtPSD
+export kl_modal_basis, modal_basis, basis_from_m2c
+export AOCalibration, ao_calibration, control_matrix
+export fitting_error
+export GainSensingCamera, calibrate!, compute_optical_gains!

--- a/src/calibration/calibration.jl
+++ b/src/calibration/calibration.jl
@@ -1,0 +1,83 @@
+"""
+    Calibration
+
+Canonical owner of inverse policy, interaction and control matrices, modal
+basis construction, model-derived NCPA synthesis, fitting analysis, optical
+gain calibration, and registration-identification workflows.
+"""
+module Calibration
+
+using KernelAbstractions
+using LinearAlgebra
+using Random
+using SparseArrays
+using Statistics
+
+import ..AdaptiveOpticsSim:
+    DimensionMismatchError,
+    FastProfile,
+    FidelityProfile,
+    InvalidConfiguration,
+    NumericalConditionError,
+    ScientificProfile,
+    UnsupportedAlgorithm,
+    calibration_profile,
+    default_fidelity_profile,
+    fftfreq!,
+    fftshift2d!
+
+import ..Backends:
+    AbstractArrayBackend,
+    AcceleratorStyle,
+    CPUBackend,
+    ExecutionStyle,
+    ScalarCPUStyle,
+    _resolve_array_backend,
+    backend_fill,
+    backend_sum_value,
+    execute_fft_plan!,
+    execution_style,
+    gpu_backend_name,
+    launch_kernel!,
+    plan_fft_backend!,
+    plan_ifft_backend!,
+    use_host_build_algebra
+
+using ..Optics
+import ..Optics:
+    AbstractSource,
+    NCPA,
+    actuator_coordinates,
+    anamorphosis_angle_deg,
+    misregistration_component,
+    rotation_deg,
+    sampled_influence_matrix,
+    supports_dm_misregistration_identification,
+    topology,
+    topology_axis_count
+
+using ..Atmospheres
+using ..Detectors
+import ..Detectors:
+    detector_noise_symbol,
+    detector_readout_sigma
+
+import ..WavefrontSensors
+using ..WavefrontSensors
+import ..WavefrontSensors:
+    AbstractWFS,
+    apply_shift_wfs!
+
+include("inverse_policies.jl")
+include("modal_basis.jl")
+include("ncpa.jl")
+include("interaction_matrix.jl")
+include("control_matrix.jl")
+include("fitting_error.jl")
+include("ao_calibration.jl")
+include("gain_sensing_camera.jl")
+include("misregistration_identification.jl")
+include("ad_sensitivities.jl")
+include("api.jl")
+
+end # module Calibration

--- a/src/calibration/inverse_policies.jl
+++ b/src/calibration/inverse_policies.jl
@@ -1,3 +1,4 @@
+# Calibration-time inverse construction policies and backend materialization.
 abstract type InversePolicy end
 abstract type BuildBackend end
 

--- a/src/calibration/ncpa.jl
+++ b/src/calibration/ncpa.jl
@@ -7,8 +7,8 @@
 # - externally supplied modal-to-command bases (`M2C`)
 #
 # The physical `NCPA` representation and explicit surface application are
-# owned by `Optics`. This file retains model-derived KL/Zernike/M2C
-# construction until the `Calibration` namespace migration moves the policy.
+# owned by `Optics`. `Calibration` owns this model-derived KL/Zernike/M2C
+# construction policy and adds synthesis constructors to the physical type.
 #
 abstract type NCPABasis end
 struct KLBasis{M<:KLBasisMethod} <: NCPABasis

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -7,21 +7,10 @@
 
 export AdaptiveOpticsSimError, InvalidConfiguration, DimensionMismatchError
 export UnsupportedAlgorithm, NumericalConditionError
-export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Plant
+export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Calibration, Plant
 
 export FidelityProfile, ScientificProfile, FastProfile, default_fidelity_profile
 export runtime_rng, deterministic_reference_rng
-
-export InversePolicy, ExactPseudoInverse, TSVDInverse, TikhonovInverse, default_modal_inverse_policy
-export KLBasis, ZernikeModalBasis
-
-export InteractionMatrix, interaction_matrix
-export ControlMatrix
-export ModalBasis, KLDMModes, KLHHtPSD
-export kl_modal_basis, modal_basis, basis_from_m2c
-export AOCalibration, ao_calibration, control_matrix
-export fitting_error
-export GainSensingCamera, calibrate!, compute_optical_gains!
 
 export NullReconstructor, ModalReconstructor, FactorizedReconstructor, MappedReconstructor
 export ControlledReconstructor

--- a/src/wfs/lift.jl
+++ b/src/wfs/lift.jl
@@ -740,6 +740,50 @@ diagnostics(lift::LiFT) = lift.state.diagnostics
 @inline _lift_model(lift::LiFT) = lift.forward.model
 @inline _lift_workspace(lift::LiFT) = lift.forward.workspace
 
+@kernel function lift_basis_expansion_kernel!(opd, basis, coeffs, pupil, n_modes::Int)
+    I = @index(Global, Cartesian)
+    i, j = Tuple(I)
+    if i <= size(opd, 1) && j <= size(opd, 2)
+        value = zero(eltype(opd))
+        @inbounds for k in 1:n_modes
+            value += coeffs[k] * basis[i, j, k]
+        end
+        @inbounds opd[i, j] = ifelse(pupil[i, j], value, zero(value))
+    end
+end
+
+@inline function lift_basis_expansion!(opd::AbstractMatrix{T},
+    basis::AbstractArray{T,3}, coeffs::AbstractVector{T},
+    pupil::AbstractMatrix{Bool}) where {T<:AbstractFloat}
+    return lift_basis_expansion!(execution_style(opd), opd, basis, coeffs,
+        pupil)
+end
+
+function lift_basis_expansion!(::ScalarCPUStyle, opd::AbstractMatrix{T},
+    basis::AbstractArray{T,3}, coeffs::AbstractVector{T},
+    pupil::AbstractMatrix{Bool}) where {T<:AbstractFloat}
+    n_modes = min(size(basis, 3), length(coeffs))
+    fill!(opd, zero(T))
+    @inbounds for k in 1:n_modes
+        @views @. opd += coeffs[k] * basis[:, :, k]
+    end
+    @. opd *= pupil
+    return opd
+end
+
+function lift_basis_expansion!(style::AcceleratorStyle,
+    opd::AbstractMatrix{T}, basis::AbstractArray{T,3},
+    coeffs::AbstractVector{T}, pupil::AbstractMatrix{Bool}) where {T<:AbstractFloat}
+    n_modes = min(size(basis, 3), length(coeffs))
+    if iszero(n_modes)
+        fill!(opd, zero(T))
+        return opd
+    end
+    launch_kernel!(style, lift_basis_expansion_kernel!, opd, basis, coeffs,
+        pupil, n_modes; ndrange=size(opd))
+    return opd
+end
+
 """
     prepare_opd!(lift, coeffs)
 
@@ -749,7 +793,7 @@ diversity OPD.
 @inline function prepare_opd!(lift::LiFT, coeffs::AbstractVector)
     model = _lift_model(lift)
     workspace = _lift_workspace(lift)
-    combine_basis!(workspace.opd_buffer, model.basis, coeffs,
+    lift_basis_expansion!(workspace.opd_buffer, model.basis, coeffs,
         model.pupil_mask)
     @. workspace.opd_buffer += model.diversity_opd
     return workspace.opd_buffer

--- a/src/wfs/wavefront_sensors.jl
+++ b/src/wfs/wavefront_sensors.jl
@@ -24,7 +24,6 @@ import ..AdaptiveOpticsSim:
     bin2d_abs2!,
     bin2d_abs2_kernel!,
     center_resize2d!,
-    combine_basis!,
     edge_geometric_slopes!,
     ensure_psf_buffers!,
     geometric_slopes!,

--- a/test/amdgpu/extension_coverage.jl
+++ b/test/amdgpu/extension_coverage.jl
@@ -16,9 +16,9 @@ AMDGPU.functional() ||
     Backends.execute_fft_plan!(fft_buffer, inverse_plan)
     @test Array(fft_buffer) ≈ original rtol=2f-5 atol=2f-5
 
-    build_backend = AdaptiveOpticsSim.default_build_backend(fft_buffer)
+    build_backend = Calibration.default_build_backend(fft_buffer)
     build_input = Float32[1 2; 3 4]
-    @test AdaptiveOpticsSim.prepare_build_matrix(
+    @test Calibration.prepare_build_matrix(
         build_backend, build_input) == build_input
     @test Backends.reduction_execution_plan(
         fft_buffer) isa Backends.HostMirrorReductionPlan
@@ -100,11 +100,11 @@ AMDGPU.functional() ||
     inverse_host = Float32[2 0; 0 1]
     inverse_input = AMDGPU.ROCArray(inverse_host)
     for policy in (
-        AdaptiveOpticsSim.ExactPseudoInverse(),
-        AdaptiveOpticsSim.TSVDInverse(rtol=1.0f-6),
-        AdaptiveOpticsSim.TikhonovInverse(0.1f0),
+        Calibration.ExactPseudoInverse(),
+        Calibration.TSVDInverse(rtol=1.0f-6),
+        Calibration.TikhonovInverse(0.1f0),
     )
-        inverse, stats = AdaptiveOpticsSim.inverse_operator(
+        inverse, stats = Calibration.inverse_operator(
             build_backend, inverse_input, policy)
         @test size(inverse) == reverse(size(inverse_host))
         @test all(isfinite, Array(inverse))

--- a/test/contracts/namespace_migration_state.toml
+++ b/test/contracts/namespace_migration_state.toml
@@ -2,8 +2,8 @@ schema_version = 1
 name = "namespace_migration_state"
 status = "maintained"
 authority = "namespace_authority.toml"
-current_gate = "NS-06E"
-implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres"]
+current_gate = "NS-07A"
+implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration"]
 partial_owners = ["WavefrontSensors"]
 
 [owner_sources]
@@ -11,6 +11,7 @@ Backends = "src/backends/api.jl"
 Optics = "src/optics/api.jl"
 Detectors = "src/detectors/api.jl"
 Atmospheres = "src/atmosphere/api.jl"
+Calibration = "src/calibration/api.jl"
 
 [partial_owner_sources]
 WavefrontSensors = "src/wfs/api.jl"

--- a/test/ka_cpu_matrix.jl
+++ b/test/ka_cpu_matrix.jl
@@ -982,16 +982,25 @@ end
         coeffs = [0.25, -0.5]
         scalar_opd = Matrix{Float64}(undef, 4, 4)
         ka_opd = similar(scalar_opd)
-        AdaptiveOpticsSim.combine_basis!(SCALAR_CPU_STYLE, scalar_opd, basis, coeffs, pupil)
-        AdaptiveOpticsSim.combine_basis!(KA_CPU_STYLE, ka_opd, basis, coeffs, pupil)
+        AdaptiveOpticsSim.Calibration.combine_basis!(
+            SCALAR_CPU_STYLE, scalar_opd, basis, coeffs, pupil)
+        AdaptiveOpticsSim.Calibration.combine_basis!(
+            KA_CPU_STYLE, ka_opd, basis, coeffs, pupil)
         mark_ka_cpu_kernel!(:combine_basis_kernel!)
         @test ka_cpu_close(ka_opd, scalar_opd)
 
         fill!(ka_opd, 1.0)
         empty_basis = Array{Float64}(undef, 4, 4, 0)
-        AdaptiveOpticsSim.combine_basis!(
+        AdaptiveOpticsSim.Calibration.combine_basis!(
             KA_CPU_STYLE, ka_opd, empty_basis, Float64[], pupil)
         @test all(iszero, ka_opd)
+
+        WavefrontSensors.lift_basis_expansion!(
+            SCALAR_CPU_STYLE, scalar_opd, basis, coeffs, pupil)
+        WavefrontSensors.lift_basis_expansion!(
+            KA_CPU_STYLE, ka_opd, basis, coeffs, pupil)
+        mark_ka_cpu_kernel!(:lift_basis_expansion_kernel!)
+        @test ka_cpu_close(ka_opd, scalar_opd)
 
         dm_scalar = DeformableMirror(tel; n_act=3, influence_width=0.3)
         dm_ka = DeformableMirror(tel; n_act=3, influence_width=0.3)

--- a/test/runtests_head.jl
+++ b/test/runtests_head.jl
@@ -6,6 +6,7 @@ using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra
@@ -78,6 +79,14 @@ for name in names(WavefrontSensors; all=true)
             !isdefined(@__MODULE__, name)
         @eval const $(name) =
             getfield(WavefrontSensors, $(QuoteNode(name)))
+    end
+end
+
+for name in names(Calibration; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) = getfield(Calibration, $(QuoteNode(name)))
     end
 end
 
@@ -256,7 +265,8 @@ function assert_ao_calibration_contract(calib::AOCalibration, n_commands::Int, n
     @test calib.calibration isa ControlMatrix
 end
 
-function assert_meta_sensitivity_contract(meta::AdaptiveOpticsSim.MetaSensitivity, n_fields::Int)
+function assert_meta_sensitivity_contract(meta::Calibration.MetaSensitivity,
+    n_fields::Int)
     @test meta.calib0 isa ControlMatrix
     @test meta.meta isa ControlMatrix
     @test length(meta.field_order) == n_fields

--- a/test/testsets/calibration_workflows.jl
+++ b/test/testsets/calibration_workflows.jl
@@ -84,24 +84,25 @@ end
     dm = DeformableMirror(tel; n_act=2, influence_width=0.4)
     wfs = ShackHartmannWFS(tel; n_lenslets=2)
     basis = modal_basis(dm, tel; n_modes=2)
-    fields = collect(AdaptiveOpticsSim.MISREG_FIELDS)
+    fields = collect(Calibration.MISREG_FIELDS)
     meta, meta_fd, meta_ad = mktempdir() do root
         cd(root) do
             @test isempty(readdir())
-            local_meta = AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+            local_meta = Calibration.compute_meta_sensitivity_matrix(
                 tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2)
-            local_fd = AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+            local_fd = Calibration.compute_meta_sensitivity_matrix(
                 tel, dm, wfs, basis.M2C[:, 1:2];
                 n_mis_reg=length(fields), field_order=fields,
                 sensitivity=:finite_difference)
-            local_ad = AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+            local_ad = Calibration.compute_meta_sensitivity_matrix(
                 tel, dm, wfs, basis.M2C[:, 1:2];
                 n_mis_reg=length(fields), field_order=fields)
             @test isempty(readdir())
             return local_meta, local_fd, local_ad
         end
     end
-    est = AdaptiveOpticsSim.estimate_misregistration(meta, meta.calib0.D; misregistration_zero=Misregistration())
+    est = Calibration.estimate_misregistration(
+        meta, meta.calib0.D; misregistration_zero=Misregistration())
     @test est.shift_x ≈ 0.0
     @test est.shift_y ≈ 0.0
 
@@ -111,13 +112,13 @@ end
 
     mktempdir() do root
         cache_path = joinpath(root, "meta-sensitivity.bin")
-        @test_throws MethodError AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+        @test_throws MethodError Calibration.compute_meta_sensitivity_matrix(
             tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2,
             cache_path=cache_path)
-        @test_throws MethodError AdaptiveOpticsSim.SPRINT(
+        @test_throws MethodError Calibration.SPRINT(
             tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2,
             save_sensitivity=false)
-        @test_throws MethodError AdaptiveOpticsSim.SPRINT(
+        @test_throws MethodError Calibration.SPRINT(
             tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2,
             recompute_sensitivity=true)
         @test !ispath(cache_path)
@@ -127,11 +128,11 @@ end
     sampled_topology = SampledActuatorTopology(actuator_coordinates(dm)[:, 1:2])
     measured_dm = DeformableMirror(tel; topology=sampled_topology,
         influence_model=MeasuredInfluenceFunctions(Array(dm.state.modes[:, 1:2])))
-    @test_throws UnsupportedAlgorithm AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    @test_throws UnsupportedAlgorithm Calibration.compute_meta_sensitivity_matrix(
         tel, measured_dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2)
-    @test_throws UnsupportedAlgorithm AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    @test_throws UnsupportedAlgorithm Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2, wfs_mis_registered=true)
-    @test_throws InvalidConfiguration AdaptiveOpticsSim.compute_meta_sensitivity_matrix(
+    @test_throws InvalidConfiguration Calibration.compute_meta_sensitivity_matrix(
         tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2, wfs_mis_registered=true,
         sensitivity=:finite_difference)
 end
@@ -169,23 +170,25 @@ end
     assert_ao_calibration_contract(calib, length(dm.state.coefs), 2)
     @test calib.calibration.D == imat_basis.matrix
 
-    meta = AdaptiveOpticsSim.compute_meta_sensitivity_matrix(tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2)
+    meta = Calibration.compute_meta_sensitivity_matrix(
+        tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2)
     assert_meta_sensitivity_contract(meta, 2)
 
-    sprint = AdaptiveOpticsSim.SPRINT(tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2)
-    @test sprint.meta isa AdaptiveOpticsSim.MetaSensitivity
+    sprint = Calibration.SPRINT(
+        tel, dm, wfs, basis.M2C[:, 1:2]; n_mis_reg=2)
+    @test sprint.meta isa Calibration.MetaSensitivity
     @test !hasfield(typeof(sprint), :cache_path)
     @test !hasfield(typeof(sprint), :save_sensitivity)
     @test !hasfield(typeof(sprint), :recompute_sensitivity)
-    est = AdaptiveOpticsSim.estimate!(sprint, meta.calib0.D)
+    est = Calibration.estimate!(sprint, meta.calib0.D)
     @test est isa Misregistration
     mktempdir() do root
         cd(root) do
-            refreshed = AdaptiveOpticsSim.estimate!(sprint, meta.calib0.D;
+            refreshed = Calibration.estimate!(sprint, meta.calib0.D;
                 n_update_zero_point=1, tel=tel, dm=dm, wfs=wfs,
                 basis=basis.M2C[:, 1:2])
             @test refreshed isa Misregistration
-            @test sprint.meta isa AdaptiveOpticsSim.MetaSensitivity
+            @test sprint.meta isa Calibration.MetaSensitivity
             @test isempty(readdir())
         end
     end

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -35,7 +35,8 @@ TestAbstractFFTs.plan_ifft!(::TestBackendFFTArray, dims) = (:backend_ifft, dims)
     @test backend(zeros(2, 2)) isa CPUBackend
     @test backend(zeros(2)) isa CPUBackend
     @test available_gpu_backends() == ()
-    @test AdaptiveOpticsSim.GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.CUDABackendTag) isa AdaptiveOpticsSim.GPUArrayBuildBackend{AdaptiveOpticsSim.Backends.CUDABackendTag}
+    @test Calibration.GPUArrayBuildBackend(AdaptiveOpticsSim.Backends.CUDABackendTag) isa
+        Calibration.GPUArrayBuildBackend{AdaptiveOpticsSim.Backends.CUDABackendTag}
 end
 
 @testset "CPU FFT provider dispatch" begin
@@ -461,7 +462,7 @@ end
         @test !isdefined(AdaptiveOpticsSim, removed_name)
         @test !Base.isexported(AdaptiveOpticsSim, removed_name)
     end
-    @test AdaptiveOpticsSim.CPUBuildBackend() isa AdaptiveOpticsSim.BuildBackend
+    @test Calibration.CPUBuildBackend() isa Calibration.BuildBackend
 end
 
 @testset "Optical radiometry and combination contracts" begin

--- a/test/testsets/namespace_authority.jl
+++ b/test/testsets/namespace_authority.jl
@@ -115,6 +115,8 @@ function adaptive_optics_sim_extension_hooks(path::AbstractString)
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Atmospheres\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
         "WavefrontSensors" =>
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?WavefrontSensors\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
+        "Calibration" =>
+            r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Calibration\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
     )
     owners = Dict{String,String}()
     for (owner, pattern) in patterns

--- a/test/testsets/optical_analysis.jl
+++ b/test/testsets/optical_analysis.jl
@@ -26,20 +26,20 @@ end
     calibrate!(gsc, frame)
     og = compute_optical_gains!(gsc, frame)
     @test length(og) == 3
-    @test length(AdaptiveOpticsSim.weak_mode_mask(gsc)) == 3
+    @test length(Calibration.weak_mode_mask(gsc)) == 3
     @test all(isfinite, og)
-    @test AdaptiveOpticsSim.detector_metadata(gsc) === nothing
+    @test Calibration.detector_metadata(gsc) === nothing
 
     weak_gsc = GainSensingCamera(mask, zeros(8, 8, 2); sensitivity_floor=1e-6)
     calibrate!(weak_gsc, frame)
     weak_og = compute_optical_gains!(weak_gsc, frame)
-    @test all(AdaptiveOpticsSim.weak_mode_mask(weak_gsc))
+    @test all(Calibration.weak_mode_mask(weak_gsc))
     @test weak_og == ones(2)
 
     det = Detector(noise=NoiseReadout(1e-3), integration_time=2.0, qe=0.8, psf_sampling=2, binning=4)
     gsc_with_det = GainSensingCamera(mask, basis; detector=det)
-    metadata = AdaptiveOpticsSim.detector_metadata(gsc_with_det)
-    @test metadata isa AdaptiveOpticsSim.GSCDetectorMetadata
+    metadata = Calibration.detector_metadata(gsc_with_det)
+    @test metadata isa Calibration.GSCDetectorMetadata
     @test metadata.integration_time == 2.0
     @test metadata.qe == 0.8
     @test metadata.psf_sampling == 2
@@ -48,10 +48,11 @@ end
     @test metadata.readout_sigma == 1e-3
     @test occursin("psf_sampling=2", sprint(show, MIME"text/plain"(), gsc_with_det))
 
-    AdaptiveOpticsSim.detach_detector!(gsc_with_det)
-    @test AdaptiveOpticsSim.detector_metadata(gsc_with_det) === nothing
-    AdaptiveOpticsSim.attach_detector!(gsc_with_det, det)
-    @test AdaptiveOpticsSim.detector_metadata(gsc_with_det) isa AdaptiveOpticsSim.GSCDetectorMetadata
+    Calibration.detach_detector!(gsc_with_det)
+    @test Calibration.detector_metadata(gsc_with_det) === nothing
+    Calibration.attach_detector!(gsc_with_det, det)
+    @test Calibration.detector_metadata(gsc_with_det) isa
+        Calibration.GSCDetectorMetadata
 end
 
 @testset "Phase statistics" begin

--- a/test/testsets/optics_ncpa.jl
+++ b/test/testsets/optics_ncpa.jl
@@ -7,32 +7,35 @@
     apply_surface!(pupil, map, DMReplace())
     @test sum(pupil.opd) ≈ 64.0
     sampled_opd = fill(3e-9, 8, 8)
-    physical_ncpa = NCPA(sampled_opd)
+    physical_ncpa = @inferred NCPA(sampled_opd)
     @test surface_opd(physical_ncpa) === sampled_opd
     @test fieldnames(typeof(physical_ncpa)) == (:opd,)
+    @test parentmodule(typeof(physical_ncpa)) === Optics
+    @test parentmodule(typeof(KLBasis())) === Calibration
 
-    basis_default = AdaptiveOpticsSim.ncpa_basis(KLBasis(), tel, dm, atm; n_modes=2)
-    basis_hht = AdaptiveOpticsSim.ncpa_basis(KLBasis(KLHHtPSD()), tel, dm, atm; n_modes=2)
-    basis_dm = AdaptiveOpticsSim.ncpa_basis(KLBasis(KLDMModes()), tel, dm, atm; n_modes=2)
+    basis_default = Calibration.ncpa_basis(KLBasis(), tel, dm, atm; n_modes=2)
+    basis_hht = Calibration.ncpa_basis(KLBasis(KLHHtPSD()), tel, dm, atm; n_modes=2)
+    basis_dm = Calibration.ncpa_basis(KLBasis(KLDMModes()), tel, dm, atm; n_modes=2)
     basis_dm_without_atmosphere =
-        AdaptiveOpticsSim.ncpa_basis(KLBasis(KLDMModes()), tel, dm; n_modes=2)
+        Calibration.ncpa_basis(KLBasis(KLDMModes()), tel, dm; n_modes=2)
     @test basis_default ≈ basis_hht
     @test sum(abs.(basis_default .- basis_dm)) > 0
     @test basis_dm_without_atmosphere ≈ basis_dm
-    @test_throws InvalidConfiguration AdaptiveOpticsSim.ncpa_basis(
+    @test_throws InvalidConfiguration Calibration.ncpa_basis(
         KLBasis(KLHHtPSD()), tel, dm; n_modes=2)
 
     modal_to_command, _ =
         kl_modal_basis(KLDMModes(), dm, tel; n_modes=2)
-    @test_throws InvalidConfiguration AdaptiveOpticsSim.ncpa_basis(
+    @test_throws InvalidConfiguration Calibration.ncpa_basis(
         M2CBasis(), tel, dm; n_modes=2)
-    external_basis = AdaptiveOpticsSim.ncpa_basis(
+    external_basis = Calibration.ncpa_basis(
         M2CBasis(), tel, dm, atm; n_modes=2, M2C=modal_to_command)
     @test external_basis ≈
         basis_from_m2c(dm, tel, modal_to_command)
 
     coeffs = [1e-9, 2e-9]
-    ncpa_default_kl = NCPA(tel, dm, atm; basis=KLBasis(), coefficients=coeffs)
+    ncpa_default_kl = @inferred NCPA(
+        tel, dm, atm; basis=KLBasis(), coefficients=coeffs)
     ncpa_hht = NCPA(tel, dm, atm; basis=KLBasis(KLHHtPSD()), coefficients=coeffs)
     ncpa_dm = NCPA(tel, dm, atm; basis=KLBasis(KLDMModes()), coefficients=coeffs)
     ncpa_zero = NCPA(tel, dm, atm)
@@ -40,6 +43,16 @@
     @test all(iszero, ncpa_zero.opd)
     @test ncpa_default_kl.opd ≈ ncpa_hht.opd
     @test sum(abs.(ncpa_default_kl.opd .- ncpa_dm.opd)) > 0
+
+    expanded_opd = similar(pupil.opd)
+    @test @inferred(Calibration.combine_basis!(
+        expanded_opd, basis_dm, coeffs, pupil_mask(tel))) === expanded_opd
+    if coverage_instrumented()
+        @test_skip "allocation assertions are disabled under coverage instrumentation"
+    else
+        @test @allocated(Calibration.combine_basis!(
+            expanded_opd, basis_dm, coeffs, pupil_mask(tel))) == 0
+    end
 
     amplitude = 2e-9
     random_ncpa = NCPA(tel, dm, atm;

--- a/test/tomography.jl
+++ b/test/tomography.jl
@@ -166,7 +166,7 @@ end
         tomo,
         dm;
         fitting=fitting,
-        build_backend=AdaptiveOpticsSim.CPUBuildBackend(),
+        build_backend=Calibration.CPUBuildBackend(),
     )
     @test recon_cpu.reconstructor isa Matrix
     @test recon_cpu.grid_mask isa Matrix{Bool}
@@ -208,7 +208,7 @@ end
         wfs,
         tomo,
         dm;
-        build_backend=AdaptiveOpticsSim.CPUBuildBackend(),
+        build_backend=Calibration.CPUBuildBackend(),
     )
     @test model_cpu.reconstructor isa Matrix
     @test model_cpu.grid_mask isa Matrix{Bool}
@@ -300,7 +300,7 @@ end
     cmd_recon_cpu = assemble_reconstructor_and_fitting(
         model_recon,
         dm;
-        build_backend=AdaptiveOpticsSim.CPUBuildBackend(),
+        build_backend=Calibration.CPUBuildBackend(),
     )
     @test cmd_recon_cpu.matrix isa Matrix
     commands = dm_commands(cmd_recon, [0.1, -0.2])


### PR DESCRIPTION
Closes #150.

## Summary
- establish `AdaptiveOpticsSim.Calibration` as the single owner of calibration synthesis, modal bases, interaction/control matrices, inverse policies, gain sensing, and NCPA synthesis workflows
- remove superseded root exports and migrate package callers, examples, benchmarks, scripts, tests, documentation, and the AMDGPU extension directly
- preserve `Optics.NCPA` as the physical optical product while extending its construction from `Calibration`
- remove the reverse Atmospheres-to-Calibration dependency and give LiFT a WFS-owned basis-expansion kernel

## Validation
- focused calibration, NCPA, atmosphere, WFS/LiFT, control, namespace, interface, tutorial/reference, and KA CPU suites pass
- full CPU composition: pass in one invocation
- all bounded Linux, macOS, and Windows shards: pass
- project and shard coverage jobs: pass
- AppleAccelerate FFT and Metal extension closure: pass
- AMDGPU extension coverage: 39/39
- AMDGPU complete GPU smoke matrix: pass
- CUDA extension coverage on Julia 1.12.6 / WSL: 18/18
- CUDA complete GPU smoke matrix on Julia 1.12.6 / WSL: pass

## Review
No unresolved findings. The exact `Calibration` export set matches the authority contract, root has no exported/public compatibility surface, `Optics.NCPA` remains the physical type, and the domain dependency graph is acyclic.

## Compatibility
This is an intentional breaking namespace refactor. No deprecated aliases, forwarding, or compatibility adapters are added.