### PR TITLE
NS-07B: establish the Control namespace owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ slopes = measure!(wfs, pupil, src)
 
 ```julia
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)
 imat = interaction_matrix(dm, wfs, PupilFunction(tel), src; amplitude=0.1)

--- a/benchmarks/benchmark_control_operators.jl
+++ b/benchmarks/benchmark_control_operators.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 using Statistics
@@ -40,7 +41,7 @@ end
 
 operator_storage_bytes(operator) = sum(
     Base.summarysize,
-    AdaptiveOpticsSim.runtime_reconstructor_storage(operator),
+    Control.runtime_reconstructor_storage(operator),
 )
 
 function print_result(label, result, storage_bytes)

--- a/benchmarks/benchmark_cpu_hotpath_cards.jl
+++ b/benchmarks/benchmark_cpu_hotpath_cards.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Control
 using BenchmarkTools
 using LinearAlgebra
 

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using BenchmarkTools
 using Random
 

--- a/benchmarks/support/closed_loop_workload.jl
+++ b/benchmarks/support/closed_loop_workload.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 
 mutable struct ClosedLoopWorkload{
     S,A,R,P,O,W,C,V,RNG,T,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,14 +16,15 @@ by `using AdaptiveOpticsSim.Optics`, backend vocabulary imported by
 `using AdaptiveOpticsSim.Backends`, conventional detector vocabulary imported
 by `using AdaptiveOpticsSim.Detectors`, atmosphere vocabulary imported by
 `using AdaptiveOpticsSim.Atmospheres`, calibration vocabulary imported by
-`using AdaptiveOpticsSim.Calibration`, the routine plant workflow imported by
+`using AdaptiveOpticsSim.Calibration`, control vocabulary imported by
+`using AdaptiveOpticsSim.Control`, the routine plant workflow imported by
 `using AdaptiveOpticsSim.Plant`, and stable qualified APIs addressed through
 their canonical modules. Qualified public names are maintained but do not
 enter the caller's ordinary namespace. The root package exports the canonical
 modules, not compatibility exports for their moved contents.
 
 The breaking namespace migration is in progress. `Backends`, `Optics`,
-`Atmospheres`, `Detectors`, and `Calibration` are complete. `Atmospheres` owns atmosphere
+`Atmospheres`, `Detectors`, `Calibration`, and `Control` are complete. `Atmospheres` owns atmosphere
 models and state, source-direction rendering and batching, and
 atmosphere-coupled propagation. `Detectors` owns both conventional frame/area
 and counting/channel sensor APIs. `Optics` owns
@@ -1348,7 +1349,7 @@ measurements remain mutable between repeated executions of a compatible plan.
 centroiding. Supplying a window is rejected rather than silently ignored;
 windowed, correlation, and matched-filter estimators remain future policies.
 
-## Calibration And Reconstruction
+## Calibration
 
 Import the maintained calibration surface explicitly:
 
@@ -1373,6 +1374,15 @@ using AdaptiveOpticsSim.Calibration
   finite-difference validation steps, and ordered parameter names
 - Structured configuration snapshots use qualified
   `AdaptiveOpticsSim.config_dict` and `AdaptiveOpticsSim.snapshot_config`
+
+## Control
+
+Import the maintained control surface explicitly:
+
+```julia
+using AdaptiveOpticsSim.Control
+```
+
 - Reconstructors: `NullReconstructor`, `ModalReconstructor`,
   `FactorizedReconstructor`, `MappedReconstructor`,
   `ControlledReconstructor`, `reconstruct!`, `reconstruct`
@@ -1392,8 +1402,9 @@ the canonical representation of these results.
 - HIL-neutral orchestration: the `AdaptiveOpticsSim.Plant` definitions,
   prepared owners, command lifecycle, triggers, detector lifecycles, and event
   loop documented above
-- Independent control primitives: `VectorDelayLine`, `shift_delay!`,
-  `DiscreteIntegratorController`, `reconstruct!`, and `set_command!`
+- Independent `AdaptiveOpticsSim.Control` primitives: `VectorDelayLine`,
+  `shift_delay!`, `DiscreteIntegratorController`, and `reconstruct!`; command
+  application remains the `AdaptiveOpticsSim.Optics.set_command!` operation
 - WFS preparation helper: `prepare_runtime_wfs!` prepares the retained WFS
   family-specific scratch required by explicit model loops
 - Generic timing helper: `runtime_timing`

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -804,6 +804,8 @@ co-conjugated surfaces add on the same path.
 Controllers own temporal behavior. Reconstructors own measurement-to-command
 operators.
 
+Import the maintained surface with `using AdaptiveOpticsSim.Control`.
+
 Use this split:
 
 - reconstructors expose the command operator and any diagnostics needed by
@@ -832,7 +834,7 @@ truncation is not evidence that discarded modes are acceptable for a real
 plant. The dense `ModalReconstructor` remains the full-rank accuracy baseline.
 
 Accelerator reconstructors must implement
-`AdaptiveOpticsSim.runtime_reconstructor_storage(reconstructor)` and return a tuple containing
+`AdaptiveOpticsSim.Control.runtime_reconstructor_storage(reconstructor)` and return a tuple containing
 their hot-path control matrices and workspaces. A model or Plant extension uses
 this contract to reject mixed host/device control paths during preparation.
 Return `()` only for a truly backend-agnostic operator. Synchronize at an
@@ -840,10 +842,11 @@ explicit observation, transport, or measurement boundary rather than inside an
 otherwise device-resident chain.
 
 Stateful reconstructors should additionally implement
-`AdaptiveOpticsSim.runtime_reconstructor_ownership_roots(reconstructor)` and
+`AdaptiveOpticsSim.Control.runtime_reconstructor_ownership_roots(reconstructor)` and
 return their mutable workspaces. This prevents two threaded ensemble members
 from sharing operator scratch state. Stateful controllers used inside
-`ControlledReconstructor` implement `runtime_controller_storage` for backend
+`ControlledReconstructor` implement
+`AdaptiveOpticsSim.Control.runtime_controller_storage` for backend
 residency; controller objects are conservatively treated as mutable ownership
 roots by default.
 

--- a/docs/julia-tutorial-mappings.md
+++ b/docs/julia-tutorial-mappings.md
@@ -58,6 +58,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 ```
 
 ### Image formation

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -92,7 +92,8 @@ Fresnel propagation, direct imaging, sampled OPD, physical NCPA, controllable
 optics, and reusable physical WFS components. `Calibration` owns inverse
 policy, interaction/control matrices, modal basis construction, model-derived
 NCPA synthesis, fitting, optical-gain calibration, and registration
-identification. `Control`, `Tomography`, and `Ensembles` follow in dependency
+identification. `Control` owns reconstruction and controller composition;
+`Tomography` and `Ensembles` follow in dependency
 order. The
 authoritative pre-migration inventory, final exact API allowlists,
 extension-hook owners, and cross-module imports are frozen in
@@ -299,8 +300,8 @@ LiFT separately owns a prepared focal-plane forward model, caller-provided
 `LiFTObservation`, and iterative estimator state. Its prepared modal subset and
 observation contract are cold-path bindings; repeated estimation neither owns
 nor triggers detector acquisition. LiFT reconstruction is the qualified-only
-`WavefrontSensors.reconstruct!`/`WavefrontSensors.reconstruct` generic, not the
-control-reconstruction generic.
+`WavefrontSensors.reconstruct!`/`WavefrontSensors.reconstruct` generic, not
+`Control.reconstruct!`/`Control.reconstruct`.
 
 ## Execution Layers
 

--- a/docs/model-cookbook.md
+++ b/docs/model-cookbook.md
@@ -135,6 +135,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)
 interaction = interaction_matrix(
@@ -163,7 +164,8 @@ Model packages may wrap a fixed composition in model-specific `prepare!`,
 `step!`, and `readout` functions. The Subaru AO188/AO3k example modules use
 that pattern.
 
-Use `VectorDelayLine`, `DiscreteIntegratorController`, or a custom controller
+Use `AdaptiveOpticsSim.Control.VectorDelayLine`,
+`AdaptiveOpticsSim.Control.DiscreteIntegratorController`, or a custom controller
 between reconstruction and `set_command!` when the numerical experiment needs
 latency or control dynamics.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -306,8 +306,8 @@ first-call evidence in
 These contracts contain no implementation binding moves.
 The maintained implementation stage lives in
 [`namespace_migration_state.toml`](../test/contracts/namespace_migration_state.toml);
-`Backends`, `Optics`, `Atmospheres`, and `Detectors` are complete through
-NS-05.
+`Backends`, `Optics`, `Atmospheres`, `Detectors`, `WavefrontSensors`,
+`Calibration`, and `Control` are complete through NS-07B.
 `Atmospheres` owns atmosphere models and state, direction rendering and
 batching, and atmosphere-coupled propagation.
 `Detectors` owns both conventional frame/area and counting/channel APIs.
@@ -315,6 +315,9 @@ batching, and atmosphere-coupled propagation.
 telescopes, sources, optical locations/products, fields, general propagation,
 direct imaging, sampled OPD, physical NCPA, controllable optics, and reusable
 physical WFS components without changing the frozen final ownership target.
+`WavefrontSensors` owns composed sensing and estimation, `Calibration` owns
+model-derived calibration products and synthesis, and `Control` owns
+slopes-to-command reconstruction and controller composition.
 
 ### Ownership target
 

--- a/docs/runtime-dataflow.md
+++ b/docs/runtime-dataflow.md
@@ -217,8 +217,9 @@ generic runtime API. A simple closed loop can likewise compose:
 - `advance_by!` and `render_atmosphere!`
 - `set_command!` and `apply!`
 - the three WFS stages
-- `reconstruct!`
-- `VectorDelayLine` and `DiscreteIntegratorController`
+- `AdaptiveOpticsSim.Control.reconstruct!`
+- `AdaptiveOpticsSim.Control.VectorDelayLine` and
+  `AdaptiveOpticsSim.Control.DiscreteIntegratorController`
 
 This keeps reusable numerical/control primitives independent of HIL scheduling.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -58,10 +58,13 @@ The package is organized around a small set of modeling objects:
 Import optical vocabulary and reusable physical components with
 `using AdaptiveOpticsSim.Optics`; import sensing vocabulary with
 `using AdaptiveOpticsSim.WavefrontSensors`; import calibration vocabulary with
-`using AdaptiveOpticsSim.Calibration`. The common WFS contracts and the
+`using AdaptiveOpticsSim.Calibration`; import control vocabulary with
+`using AdaptiveOpticsSim.Control`. The common WFS contracts and the
 complete Shack–Hartmann, Pyramid, BioEdge, Zernike, and Curvature families
 live in `WavefrontSensors`; inverse policy, interaction/control matrices,
 modal bases, and model-derived NCPA synthesis live in `Calibration`.
+Slopes-to-command reconstructors, controller models, and their preallocated
+composition live in `Control`.
 
 ## Three Execution Layers
 
@@ -614,6 +617,7 @@ Use this when you care about:
 
 ```julia
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 
 rng = runtime_rng(0)
 dm = DeformableMirror(tel; n_act=4, influence_width=0.3)

--- a/examples/closed_loop/run_cl.jl
+++ b/examples/closed_loop/run_cl.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop/run_cl_first_stage.jl
+++ b/examples/closed_loop/run_cl_first_stage.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_from_phase_screens.jl
+++ b/examples/closed_loop/run_cl_from_phase_screens.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_long_push_pull.jl
+++ b/examples/closed_loop/run_cl_long_push_pull.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop/run_cl_sinusoidal_modulation.jl
+++ b/examples/closed_loop/run_cl_sinusoidal_modulation.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_two_stages.jl
+++ b/examples/closed_loop/run_cl_two_stages.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_two_stages_atm_change.jl
+++ b/examples/closed_loop/run_cl_two_stages_atm_change.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using Random
 using Logging
 

--- a/examples/closed_loop/run_cl_zernike.jl
+++ b/examples/closed_loop/run_cl_zernike.jl
@@ -4,6 +4,7 @@ using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 using Logging

--- a/examples/closed_loop_demo.jl
+++ b/examples/closed_loop_demo.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 

--- a/examples/support/subaru_ao188_simulation.jl
+++ b/examples/support/subaru_ao188_simulation.jl
@@ -7,6 +7,7 @@ using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 using Statistics

--- a/examples/tutorials/common.jl
+++ b/examples/tutorials/common.jl
@@ -3,6 +3,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 import AdaptiveOpticsSim.Optics: filter!
 using Logging
 using Random

--- a/scripts/gpu_builder_contract.jl
+++ b/scripts/gpu_builder_contract.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 
 function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBackendTag}

--- a/scripts/gpu_smoke_contract.jl
+++ b/scripts/gpu_smoke_contract.jl
@@ -5,6 +5,7 @@ using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using LinearAlgebra
 using Random
 using Statistics

--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -422,32 +422,20 @@ import .WavefrontSensors:
 include("plant/plant.jl")
 include("calibration/calibration.jl")
 
-# Control and tomography still await their own namespace gates. Import only
-# the calibration identities their flat implementations consume; these are
-# package-internal composition bindings, not root exports or public API.
+# Tomography still awaits its namespace gate. Import only the calibration
+# identities its flat implementation consumes; these are package-internal
+# composition bindings, not root exports or public API.
 import .Calibration:
     BuildBackend,
     CPUBuildBackend,
     GPUArrayBuildBackend,
     InteractionMatrix,
-    InversePolicy,
     NativeBuildBackend,
     default_build_backend,
-    default_modal_inverse_policy,
-    default_runtime_calibration_build_backend,
-    condition_number,
-    effective_rank,
-    inverse_factorization,
-    inverse_operator,
-    inverse_policy,
     materialize_build,
-    materialize_runtime_build_result,
-    prepare_build_matrix,
-    singular_values,
-    truncation_count
+    prepare_build_matrix
 
-include("control/controller.jl")
-include("control/reconstructors.jl")
+include("control/control.jl")
 include("control/ensemble.jl")
 include("tomography/parameters.jl")
 include("tomography/geometry.jl")

--- a/src/control/api.jl
+++ b/src/control/api.jl
@@ -1,0 +1,6 @@
+export NullReconstructor, ModalReconstructor, FactorizedReconstructor
+export MappedReconstructor, ControlledReconstructor
+export reconstruct!, reconstruct
+export DiscreteIntegratorController, VectorDelayLine, shift_delay!
+
+public controller_output, reset_controller!, supports_controller_reset

--- a/src/control/control.jl
+++ b/src/control/control.jl
@@ -1,0 +1,41 @@
+"""
+    Control
+
+Canonical owner of slopes-to-command reconstructors, discrete controller
+models, controller composition, and preallocated control-path execution.
+"""
+module Control
+
+using LinearAlgebra
+
+import ..AdaptiveOpticsSim:
+    DimensionMismatchError,
+    InvalidConfiguration
+
+import ..Backends:
+    AbstractArrayBackend,
+    CPUBackend,
+    _resolve_array_backend,
+    require_same_backend
+
+import ..Calibration:
+    BuildBackend,
+    InteractionMatrix,
+    InversePolicy,
+    condition_number,
+    default_modal_inverse_policy,
+    default_runtime_calibration_build_backend,
+    effective_rank,
+    inverse_factorization,
+    inverse_operator,
+    inverse_policy,
+    materialize_build,
+    materialize_runtime_build_result,
+    singular_values,
+    truncation_count
+
+include("controller.jl")
+include("reconstructors.jl")
+include("api.jl")
+
+end # module Control

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -7,15 +7,11 @@
 
 export AdaptiveOpticsSimError, InvalidConfiguration, DimensionMismatchError
 export UnsupportedAlgorithm, NumericalConditionError
-export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Calibration, Plant
+export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Calibration
+export Control, Plant
 
 export FidelityProfile, ScientificProfile, FastProfile, default_fidelity_profile
 export runtime_rng, deterministic_reference_rng
-
-export NullReconstructor, ModalReconstructor, FactorizedReconstructor, MappedReconstructor
-export ControlledReconstructor
-export reconstruct!, reconstruct
-export DiscreteIntegratorController, VectorDelayLine, shift_delay!
 
 export AbstractExecutionPolicy
 export SequentialExecution, ThreadedExecution, BackendStreamExecution
@@ -23,7 +19,6 @@ export DeterministicExecution, AcceleratedKernelsExecution, DaggerExecution
 export SimulationEnsemble
 export runtime_timing
 
-public controller_output, reset_controller!, supports_controller_reset
 public run_ensemble!, ensemble_members, execution_policy
 public ensemble_ownership_roots, init_ensemble_scheduler, execute_ensemble!
 public init_execution_state

--- a/test/backend_optional_common.jl
+++ b/test/backend_optional_common.jl
@@ -2773,16 +2773,16 @@ function run_optional_scalable_reconstructor_checks(::Type{T}, selector,
     AdaptiveOpticsSim.Backends.synchronize_backend!(
         AdaptiveOpticsSim.Backends.execution_style(factorized_out))
     @test Array(factorized_out) ≈ Array(dense_out) atol=T(2e-4) rtol=T(2e-4)
-    @test AdaptiveOpticsSim.factorized_rank(factorized) == n_commands
+    @test Control.factorized_rank(factorized) == n_commands
     @test all(storage -> storage isa BackendArray,
-        AdaptiveOpticsSim.runtime_reconstructor_storage(factorized))
+        Control.runtime_reconstructor_storage(factorized))
 
     compact = FactorizedReconstructor(interaction; gain=T(0.5), max_rank=3)
-    @test AdaptiveOpticsSim.factorized_rank(compact) == 3
+    @test Control.factorized_rank(compact) == 3
     @test sum(length,
-        AdaptiveOpticsSim.runtime_reconstructor_storage(compact)) <
+        Control.runtime_reconstructor_storage(compact)) <
         sum(length,
-            AdaptiveOpticsSim.runtime_reconstructor_storage(factorized))
+            Control.runtime_reconstructor_storage(factorized))
 
     controller = DiscreteIntegratorController(n_commands;
         gain=T(0.7), tau=T(0.01), T=T, backend=selector)
@@ -2792,7 +2792,7 @@ function run_optional_scalable_reconstructor_checks(::Type{T}, selector,
         AdaptiveOpticsSim.Backends.execution_style(factorized_out))
     @test all(isfinite, Array(factorized_out))
     @test all(storage -> storage isa BackendArray,
-        AdaptiveOpticsSim.runtime_reconstructor_storage(controlled))
+        Control.runtime_reconstructor_storage(controlled))
     @test AdaptiveOpticsSim.reset_controller!(controlled) === controlled
     @test_throws InvalidConfiguration ControlledReconstructor(
         factorized,

--- a/test/contracts/namespace_migration_state.toml
+++ b/test/contracts/namespace_migration_state.toml
@@ -2,8 +2,8 @@ schema_version = 1
 name = "namespace_migration_state"
 status = "maintained"
 authority = "namespace_authority.toml"
-current_gate = "NS-07A"
-implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration"]
+current_gate = "NS-07B"
+implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration", "Control"]
 partial_owners = ["WavefrontSensors"]
 
 [owner_sources]
@@ -12,6 +12,7 @@ Optics = "src/optics/api.jl"
 Detectors = "src/detectors/api.jl"
 Atmospheres = "src/atmosphere/api.jl"
 Calibration = "src/calibration/api.jl"
+Control = "src/control/api.jl"
 
 [partial_owner_sources]
 WavefrontSensors = "src/wfs/api.jl"

--- a/test/runtests_head.jl
+++ b/test/runtests_head.jl
@@ -7,6 +7,7 @@ using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra
@@ -87,6 +88,14 @@ for name in names(Calibration; all=true)
     if Base.isidentifier(s) && !startswith(s, "#") &&
             !isdefined(@__MODULE__, name)
         @eval const $(name) = getfield(Calibration, $(QuoteNode(name)))
+    end
+end
+
+for name in names(Control; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) = getfield(Control, $(QuoteNode(name)))
     end
 end
 

--- a/test/testsets/control_primitives.jl
+++ b/test/testsets/control_primitives.jl
@@ -161,9 +161,10 @@ end
     @test command_storage(dm) == command_before
     @test opd_map(pupil) == opd_before
 
-    reconstructor = FactorizedReconstructor(imat; gain=1.0)
+    reconstructor = @inferred FactorizedReconstructor(imat; gain=1.0)
     command = similar(command_storage(dm))
-    reconstruct!(command, reconstructor, slopes(wfs))
+    @test @inferred(reconstruct!(command, reconstructor, slopes(wfs))) ===
+        command
     @test length(command) == n_control_dofs(dm)
 
     delay = VectorDelayLine(command, 2)
@@ -182,12 +183,12 @@ end
     zero_delay = VectorDelayLine(command, 0)
     @test shift_delay!(zero_delay, command) == command
 
-    controller = DiscreteIntegratorController(
+    controller = @inferred DiscreteIntegratorController(
         length(command);
         gain=0.1,
         tau=0.02,
     )
-    output = update!(controller, command, 0.01)
+    output = @inferred update!(controller, command, 0.01)
     @test output === controller_output(controller)
     @test reset_controller!(controller) === controller
     @test all(iszero, controller_output(controller))
@@ -207,7 +208,8 @@ end
         );
         dt=1e-3,
     )
-    reconstruct!(command, controlled, slopes(wfs))
+    @test @inferred(reconstruct!(command, controlled, slopes(wfs))) ===
+        command
     reconstruct!(command, controlled, slopes(wfs))
     @test all(isfinite, command)
     if coverage_instrumented()

--- a/test/testsets/control_reconstruction.jl
+++ b/test/testsets/control_reconstruction.jl
@@ -16,17 +16,20 @@
     @test ControlMatrix(D_sing).policy isa TSVDInverse
 
     imat = InteractionMatrix(D_sing, 0.1)
-    recon_exact = ModalReconstructor(imat; policy=ExactPseudoInverse())
+    recon_exact = @inferred ModalReconstructor(
+        imat;
+        policy=ExactPseudoInverse(),
+    )
     recon_tsvd = ModalReconstructor(imat; policy=TSVDInverse(rtol=1e-9))
-    recon_factorized = FactorizedReconstructor(imat;
+    recon_factorized = @inferred FactorizedReconstructor(imat;
         policy=ExactPseudoInverse())
     recon_rank_one = FactorizedReconstructor(imat;
         policy=ExactPseudoInverse(), max_rank=1)
     @test recon_exact.effective_rank == 2
     @test recon_tsvd.effective_rank == 1
     @test ModalReconstructor(imat).policy isa TSVDInverse
-    @test AdaptiveOpticsSim.factorized_rank(recon_factorized) == 2
-    @test AdaptiveOpticsSim.factorized_rank(recon_rank_one) == 1
+    @test Control.factorized_rank(recon_factorized) == 2
+    @test Control.factorized_rank(recon_rank_one) == 1
     probe_slopes = [0.3, -0.2]
     dense_command = zeros(2)
     factorized_command = zeros(2)
@@ -41,7 +44,7 @@
             recon_factorized, probe_slopes)) == 0
     end
     @test sum(length,
-        AdaptiveOpticsSim.runtime_reconstructor_storage(recon_rank_one)) <
+        Control.runtime_reconstructor_storage(recon_rank_one)) <
         sum(length,
-            AdaptiveOpticsSim.runtime_reconstructor_storage(recon_factorized))
+            Control.runtime_reconstructor_storage(recon_factorized))
 end

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -305,8 +305,8 @@ end
         @test parentmodule(getfield(Detectors, name)) === Detectors
     end
     @test Base.isexported(AdaptiveOpticsSim, :SimulationEnsemble)
-    @test Base.isexported(AdaptiveOpticsSim, :FactorizedReconstructor)
-    @test Base.isexported(AdaptiveOpticsSim, :ControlledReconstructor)
+    @test Base.isexported(Control, :FactorizedReconstructor)
+    @test Base.isexported(Control, :ControlledReconstructor)
     @test Base.isexported(AdaptiveOpticsSim, :DeterministicExecution)
     @test Base.isexported(AdaptiveOpticsSim, :AcceleratedKernelsExecution)
     @test Base.isexported(AdaptiveOpticsSim, :DaggerExecution)
@@ -433,6 +433,35 @@ end
     @test !Base.isexported(AdaptiveOpticsSim, :GPUBackendTag)
     @test !Base.isexported(AdaptiveOpticsSim, :AbstractRuntimeExecutionPlan)
     @test !Base.isexported(AdaptiveOpticsSim, :runtime_reconstructor_storage)
+    for name in (
+        :NullReconstructor,
+        :ModalReconstructor,
+        :FactorizedReconstructor,
+        :MappedReconstructor,
+        :ControlledReconstructor,
+        :reconstruct!,
+        :reconstruct,
+        :DiscreteIntegratorController,
+        :VectorDelayLine,
+        :shift_delay!,
+    )
+        @test !Base.isexported(AdaptiveOpticsSim, name)
+        @test !Base.ispublic(AdaptiveOpticsSim, name)
+        @test Base.isexported(Control, name)
+        @test Base.ispublic(Control, name)
+        @test parentmodule(getfield(Control, name)) === Control
+    end
+    for name in (
+        :controller_output,
+        :reset_controller!,
+        :supports_controller_reset,
+    )
+        @test !Base.isexported(AdaptiveOpticsSim, name)
+        @test !Base.ispublic(AdaptiveOpticsSim, name)
+        @test !Base.isexported(Control, name)
+        @test Base.ispublic(Control, name)
+        @test parentmodule(getfield(Control, name)) === Control
+    end
     @test !Base.isexported(AdaptiveOpticsSim, :ensemble_ownership_roots)
     @test !Base.isexported(AdaptiveOpticsSim, :run_ensemble!)
     @test !Base.isexported(AdaptiveOpticsSim, :CUDABackendTag)

--- a/test/testsets/namespace_authority.jl
+++ b/test/testsets/namespace_authority.jl
@@ -117,6 +117,8 @@ function adaptive_optics_sim_extension_hooks(path::AbstractString)
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?WavefrontSensors\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
         "Calibration" =>
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Calibration\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
+        "Control" =>
+            r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Control\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
     )
     owners = Dict{String,String}()
     for (owner, pattern) in patterns

--- a/test/testsets/wfs_common_and_parity.jl
+++ b/test/testsets/wfs_common_and_parity.jl
@@ -56,8 +56,8 @@ struct CommonContractWFS <: WavefrontSensors.AbstractWFS end
     @test isdefined(WavefrontSensors, :reconstruct)
     @test !Base.isexported(WavefrontSensors, :reconstruct!)
     @test !Base.isexported(WavefrontSensors, :reconstruct)
-    @test WavefrontSensors.reconstruct! !== AdaptiveOpticsSim.reconstruct!
-    @test WavefrontSensors.reconstruct !== AdaptiveOpticsSim.reconstruct
+    @test WavefrontSensors.reconstruct! !== Control.reconstruct!
+    @test WavefrontSensors.reconstruct !== Control.reconstruct
     for name in (
         :ShackHartmannWFS,
         :ShackHartmannDirectFrontEnd,


### PR DESCRIPTION
Closes #151.

## Summary

- establish `AdaptiveOpticsSim.Control` as the canonical owner of reconstructors, controller composition, and delay-line primitives
- remove the superseded root exports/public names without compatibility aliases
- preserve the dependency direction `Control -> Calibration`; Calibration does not depend on Control
- keep `WavefrontSensors.reconstruct!` / `reconstruct` distinct from the Control reconstruction generic
- migrate examples, benchmarks, GPU contracts, tests, and maintained documentation to explicit `using AdaptiveOpticsSim.Control`
- freeze the exact export/public authority and add inference checks while retaining warmed zero-allocation contracts

## Validation

Exact revision: `97a9624`

- focused namespace authority, HIL inventory, baseline, core API, Control, WFS parity, and interface-conformance suites: pass
- bounded tomography, quality/Aqua, plant-controller routing, calibration workflows, reference tutorials, gate-0, and optional backend-smoke composition: pass
- local AMDGPU full smoke matrix: pass, including `closed_loop_step` and `interaction_matrix_reconstructor`
- WSL CUDA full smoke matrix: pass, including `closed_loop_step` and `interaction_matrix_reconstructor`
- `git diff --check`: pass

Full CPU/OS/coverage validation remains the PR merge gate.