### PR TITLE
NS-08: establish Tomography namespace authority

### DIFF
--- a/benchmarks/backend_benchmark_contract.jl
+++ b/benchmarks/backend_benchmark_contract.jl
@@ -1,6 +1,7 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Backends
+using AdaptiveOpticsSim.Tomography
 using BenchmarkTools
 using Random
 
@@ -138,7 +139,7 @@ function _tomography_case_params(target::BenchmarkExecutionTarget; n_lenslet::In
         n_actuators=fill(grid_side, n_dm),
         valid_actuators=valid,
     )
-    noise_model = RelativeSignalNoise(TB(0.1))
+    noise_model = Tomography.RelativeSignalNoise(TB(0.1))
     imat_rows = 2 * n_lenslet^2 * n_lgs
     grid_mask = trues(grid_side, grid_side)
     imat_cols = n_lgs * count(grid_mask)
@@ -236,7 +237,7 @@ function _builder_benchmarks(target::BenchmarkExecutionTarget, p)
             $(p.lgswfs_hi),
             $(p.tomo_hi),
             $(p.tdm_hi);
-            noise_model=RelativeSignalNoise($(AdaptiveOpticsSim.Backends.gpu_build_type(p.high_accuracy))(0.1)),
+            noise_model=Tomography.RelativeSignalNoise($(AdaptiveOpticsSim.Backends.gpu_build_type(p.high_accuracy))(0.1)),
             build_backend=$(p.build_backend),
         )
         _sync_target!($target, recon_local.reconstructor)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,14 +17,16 @@ by `using AdaptiveOpticsSim.Optics`, backend vocabulary imported by
 by `using AdaptiveOpticsSim.Detectors`, atmosphere vocabulary imported by
 `using AdaptiveOpticsSim.Atmospheres`, calibration vocabulary imported by
 `using AdaptiveOpticsSim.Calibration`, control vocabulary imported by
-`using AdaptiveOpticsSim.Control`, the routine plant workflow imported by
+`using AdaptiveOpticsSim.Control`, tomography vocabulary imported by
+`using AdaptiveOpticsSim.Tomography`, the routine plant workflow imported by
 `using AdaptiveOpticsSim.Plant`, and stable qualified APIs addressed through
 their canonical modules. Qualified public names are maintained but do not
 enter the caller's ordinary namespace. The root package exports the canonical
 modules, not compatibility exports for their moved contents.
 
 The breaking namespace migration is in progress. `Backends`, `Optics`,
-`Atmospheres`, `Detectors`, `Calibration`, and `Control` are complete. `Atmospheres` owns atmosphere
+`Atmospheres`, `Detectors`, `Calibration`, `Control`, and `Tomography` are
+complete. `Atmospheres` owns atmosphere
 models and state, source-direction rendering and batching, and
 atmosphere-coupled propagation. `Detectors` owns both conventional frame/area
 and counting/channel sensor APIs. `Optics` owns
@@ -1430,6 +1432,12 @@ For external Proper science-arm integration, use
 [`proper-integration-guide.md`](./proper-integration-guide.md).
 
 ## Tomography
+
+Import the maintained tomography surface explicitly:
+
+```julia
+using AdaptiveOpticsSim.Tomography
+```
 
 - Parameter containers: `TomographyAtmosphereParams`, `LGSAsterismParams`,
   `LGSWFSParams`, `TomographyParams`, `TomographyDMParams`

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -33,12 +33,12 @@ The owner categories are:
 - `Ensembles` for optional coarse scheduler execution
 - the root package only for cross-domain config and telemetry serialization
 
-`Backends` has completed its ownership move. Backend extensions add methods to
-`AdaptiveOpticsSim.Backends.name`; no root-package backend generic or
-forwarding method remains part of the supported API. The implemented `Optics`
-namespace likewise owns source, product, propagation, controllable-optic, and
-reusable physical-WFS-component seams under `AdaptiveOpticsSim.Optics`. Hooks
-assigned to later domain owners remain at
+Implemented domain owners, including `Backends`, `Optics`, and `Tomography`,
+receive extension methods at `AdaptiveOpticsSim.Owner.name`; no root-package
+forwarding generic remains part of the supported API. In particular,
+tomography-specific Hermitian solvers extend
+`AdaptiveOpticsSim.Tomography.stable_hermitian_right_division`. Hooks assigned
+to later domain owners remain at
 `AdaptiveOpticsSim.name` only until that owner's PR moves the generic and every
 extension method together. The maintained stage is recorded in
 [`../test/contracts/namespace_migration_state.toml`](../test/contracts/namespace_migration_state.toml).

--- a/docs/julia-tutorial-mappings.md
+++ b/docs/julia-tutorial-mappings.md
@@ -59,6 +59,7 @@ using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
+using AdaptiveOpticsSim.Tomography
 ```
 
 ### Image formation

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -93,8 +93,8 @@ optics, and reusable physical WFS components. `Calibration` owns inverse
 policy, interaction/control matrices, modal basis construction, model-derived
 NCPA synthesis, fitting, optical-gain calibration, and registration
 identification. `Control` owns reconstruction and controller composition;
-`Tomography` and `Ensembles` follow in dependency
-order. The
+`Tomography` owns guide-star geometry, atmospheric reconstruction, fitting,
+and DM-command projection; `Ensembles` follows in dependency order. The
 authoritative pre-migration inventory, final exact API allowlists,
 extension-hook owners, and cross-module imports are frozen in
 [`../test/contracts/namespace_authority.toml`](../test/contracts/namespace_authority.toml).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -307,7 +307,7 @@ These contracts contain no implementation binding moves.
 The maintained implementation stage lives in
 [`namespace_migration_state.toml`](../test/contracts/namespace_migration_state.toml);
 `Backends`, `Optics`, `Atmospheres`, `Detectors`, `WavefrontSensors`,
-`Calibration`, and `Control` are complete through NS-07B.
+`Calibration`, `Control`, and `Tomography` are complete through NS-08.
 `Atmospheres` owns atmosphere models and state, direction rendering and
 batching, and atmosphere-coupled propagation.
 `Detectors` owns both conventional frame/area and counting/channel APIs.
@@ -317,7 +317,9 @@ direct imaging, sampled OPD, physical NCPA, controllable optics, and reusable
 physical WFS components without changing the frozen final ownership target.
 `WavefrontSensors` owns composed sensing and estimation, `Calibration` owns
 model-derived calibration products and synthesis, and `Control` owns
-slopes-to-command reconstruction and controller composition.
+slopes-to-command reconstruction and controller composition. `Tomography`
+owns guide-star geometry, atmospheric reconstruction, fitting, and DM-command
+projection.
 
 ### Ownership target
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -59,7 +59,8 @@ Import optical vocabulary and reusable physical components with
 `using AdaptiveOpticsSim.Optics`; import sensing vocabulary with
 `using AdaptiveOpticsSim.WavefrontSensors`; import calibration vocabulary with
 `using AdaptiveOpticsSim.Calibration`; import control vocabulary with
-`using AdaptiveOpticsSim.Control`. The common WFS contracts and the
+`using AdaptiveOpticsSim.Control`; import tomography vocabulary with
+`using AdaptiveOpticsSim.Tomography`. The common WFS contracts and the
 complete Shack–Hartmann, Pyramid, BioEdge, Zernike, and Curvature families
 live in `WavefrontSensors`; inverse policy, interaction/control matrices,
 modal bases, and model-derived NCPA synthesis live in `Calibration`.

--- a/examples/tutorials/common.jl
+++ b/examples/tutorials/common.jl
@@ -4,6 +4,7 @@ using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
+using AdaptiveOpticsSim.Tomography
 import AdaptiveOpticsSim.Optics: filter!
 using Logging
 using Random

--- a/ext/AdaptiveOpticsSimAMDGPUExt.jl
+++ b/ext/AdaptiveOpticsSimAMDGPUExt.jl
@@ -1,7 +1,7 @@
 module AdaptiveOpticsSimAMDGPUExt
 
 import AdaptiveOpticsSim
-import AdaptiveOpticsSim: Backends, Calibration, WavefrontSensors
+import AdaptiveOpticsSim: Backends, Calibration, Tomography, WavefrontSensors
 using AMDGPU
 using AbstractFFTs
 using KernelAbstractions
@@ -394,7 +394,7 @@ The preferred path is Cholesky on the Hermitian Gram matrix. If that fails, the
 implementation falls back to LU so the higher-level algorithm remains robust on
 ill-conditioned runtime/calibration cases.
 """
-function AdaptiveOpticsSim.stable_hermitian_right_division(
+function Tomography.stable_hermitian_right_division(
     _backend::Calibration.GPUArrayBuildBackend{Backends.AMDGPUBackendTag},
     rhs::AMDGPU.ROCArray{T,2},
     gram::AMDGPU.ROCArray{T,2},

--- a/scripts/gpu_builder_contract.jl
+++ b/scripts/gpu_builder_contract.jl
@@ -2,6 +2,7 @@ using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
+using AdaptiveOpticsSim.Tomography
 using LinearAlgebra
 
 function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBackendTag}
@@ -71,7 +72,7 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
     imat_t = Calibration.materialize_build(build_backend,
         reshape(T[1.0, 0.5], 2, 1))
     imat_t_cpu = reshape(T[1.0, 0.5], 2, 1)
-    noise = AdaptiveOpticsSim.RelativeSignalNoise(T(0.1))
+    noise = AdaptiveOpticsSim.Tomography.RelativeSignalNoise(T(0.1))
 
     tr = build_reconstructor(
         InteractionMatrixTomography(),
@@ -105,8 +106,10 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
     slopes_tomo_tr_gpu = Calibration.materialize_build(build_backend,
         convert.(eltype(tr.reconstructor), slopes_tomo))
     @assert isapprox(
-        Array(AdaptiveOpticsSim.reconstruct_wavefront(tr, slopes_tomo_tr_gpu)),
-        AdaptiveOpticsSim.reconstruct_wavefront(tr_cpu, slopes_tomo);
+        Array(AdaptiveOpticsSim.Tomography.reconstruct_wavefront(
+            tr, slopes_tomo_tr_gpu)),
+        AdaptiveOpticsSim.Tomography.reconstruct_wavefront(
+            tr_cpu, slopes_tomo);
         rtol=1f-5,
         atol=1f-6,
     )
@@ -145,8 +148,10 @@ function run_gpu_builder_smoke(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.G
     slopes_tomo_mr_gpu = Calibration.materialize_build(build_backend,
         slopes_tomo_mr)
     @assert isapprox(
-        Array(AdaptiveOpticsSim.reconstruct_wavefront(mr, slopes_tomo_mr_gpu)),
-        AdaptiveOpticsSim.reconstruct_wavefront(mr_cpu, slopes_tomo_mr);
+        Array(AdaptiveOpticsSim.Tomography.reconstruct_wavefront(
+            mr, slopes_tomo_mr_gpu)),
+        AdaptiveOpticsSim.Tomography.reconstruct_wavefront(
+            mr_cpu, slopes_tomo_mr);
         rtol=1f-5,
         atol=1f-6,
     )

--- a/scripts/gpu_profile_auto_correlation_cuda.jl
+++ b/scripts/gpu_profile_auto_correlation_cuda.jl
@@ -1,5 +1,6 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.Tomography
 
 try
     using CUDA
@@ -57,32 +58,39 @@ function _profile_case(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBacken
         lenslet_offset=zeros(T, 2, n_lenslet^2),
     )
 
-    _, grid_mask = AdaptiveOpticsSim.sparse_gradient_matrix(AdaptiveOpticsSim.valid_lenslet_support(wfs); over_sampling=2)
+    _, grid_mask = AdaptiveOpticsSim.Tomography.sparse_gradient_matrix(
+        AdaptiveOpticsSim.Tomography.valid_lenslet_support(wfs);
+        over_sampling=2)
     sampling = size(grid_mask, 1)
     mask_vec = vec(grid_mask)
     valid_positions = findall(mask_vec)
     n_valid = count(mask_vec)
-    altitude = AdaptiveOpticsSim.layer_altitude_m(atmosphere)
-    r0 = AdaptiveOpticsSim._fried_parameter(atmosphere)
-    support_d = AdaptiveOpticsSim.support_diameter(wfs)
-    lgs_dir = AdaptiveOpticsSim.lgs_directions(asterism)
-    directions = AdaptiveOpticsSim.direction_vectors(view(lgs_dir, :, 1), view(lgs_dir, :, 2))
-    source_height = AdaptiveOpticsSim.lgs_height_m(asterism, atmosphere)
-    rotations, offsets_x, offsets_y = AdaptiveOpticsSim._active_guide_grid_params(
+    altitude = AdaptiveOpticsSim.Tomography.layer_altitude_m(atmosphere)
+    r0 = AdaptiveOpticsSim.Tomography._fried_parameter(atmosphere)
+    support_d = AdaptiveOpticsSim.Tomography.support_diameter(wfs)
+    lgs_dir = AdaptiveOpticsSim.Tomography.lgs_directions(asterism)
+    directions = AdaptiveOpticsSim.Tomography.direction_vectors(
+        view(lgs_dir, :, 1), view(lgs_dir, :, 2))
+    source_height =
+        AdaptiveOpticsSim.Tomography.lgs_height_m(asterism, atmosphere)
+    rotations, offsets_x, offsets_y =
+        AdaptiveOpticsSim.Tomography._active_guide_grid_params(
         wfs.lenslet_rotation_rad,
         view(wfs.lenslet_offset, 1, :),
         view(wfs.lenslet_offset, 2, :),
         n_lgs,
     )
 
-    result = AdaptiveOpticsSim._backend_array(B, T, n_lgs * n_valid, n_lgs * n_valid)
+    result = AdaptiveOpticsSim.Calibration._backend_array(
+        B, T, n_lgs * n_valid, n_lgs * n_valid)
     fill!(result, zero(T))
-    valid_positions_native = AdaptiveOpticsSim._backend_array(B, Int, length(valid_positions))
+    valid_positions_native = AdaptiveOpticsSim.Calibration._backend_array(
+        B, Int, length(valid_positions))
     copyto!(valid_positions_native, valid_positions)
     style = AdaptiveOpticsSim.Backends.execution_style(result)
 
     guide_xy, t_guides = _time_phase() do
-        gx, gy = AdaptiveOpticsSim._guide_star_grids(
+        gx, gy = AdaptiveOpticsSim.Tomography._guide_star_grids(
             backend,
             sampling,
             support_d,
@@ -97,7 +105,7 @@ function _profile_case(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBacken
     guide_x, guide_y = guide_xy
 
     shifted, t_shift = _time_phase() do
-        value = AdaptiveOpticsSim._scaled_shifted_coord_stack(
+        value = AdaptiveOpticsSim.Tomography._scaled_shifted_coord_stack(
             backend,
             guide_x,
             guide_y,
@@ -109,8 +117,11 @@ function _profile_case(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBacken
     end
     shifted_flat = reshape(shifted, :, n_lgs, length(altitude))
 
-    cst, var_term, inv_L0 = AdaptiveOpticsSim._covariance_constants(r0, atmosphere.L0)
-    block = AdaptiveOpticsSim._backend_array(B, T, n_valid, n_valid)
+    cst, var_term, inv_L0 =
+        AdaptiveOpticsSim.Tomography._covariance_constants(
+            r0, atmosphere.L0)
+    block = AdaptiveOpticsSim.Calibration._backend_array(
+        B, T, n_valid, n_valid)
     fractional_cn2_native = AdaptiveOpticsSim.Calibration.materialize_build(
         backend, atmosphere.fractional_cn2)
 
@@ -122,7 +133,7 @@ function _profile_case(::Type{B}) where {B<:AdaptiveOpticsSim.Backends.GPUBacken
             _, dt_selected = _time_phase() do
                 AdaptiveOpticsSim.Backends.launch_kernel_async!(
                     style,
-                    AdaptiveOpticsSim.selected_covariance_block_kernel!,
+                    AdaptiveOpticsSim.Tomography.selected_covariance_block_kernel!,
                     block,
                     shifted_flat,
                     valid_positions_native,

--- a/scripts/gpu_profile_model_tomography_contract.jl
+++ b/scripts/gpu_profile_model_tomography_contract.jl
@@ -1,5 +1,6 @@
 using AdaptiveOpticsSim
 using AdaptiveOpticsSim.Optics
+using AdaptiveOpticsSim.Tomography
 using Profile
 
 function _sync_backend_array!(A)
@@ -61,7 +62,7 @@ function run_gpu_model_tomography_profile(::Type{B}) where {B<:AdaptiveOpticsSim
         n_actuators=fill(grid_side, n_dm),
         valid_actuators=trues(grid_side, grid_side),
     )
-    noise_model = AdaptiveOpticsSim.RelativeSignalNoise(TB(0.1))
+    noise_model = AdaptiveOpticsSim.Tomography.RelativeSignalNoise(TB(0.1))
 
     function build_model()
         recon = build_reconstructor(
@@ -124,7 +125,8 @@ function run_gpu_model_tomography_profile(::Type{B}) where {B<:AdaptiveOpticsSim
             lgswfs_hi,
             tomo_hi,
             tdm_hi;
-            noise_model=AdaptiveOpticsSim.RelativeSignalNoise(TH(0.1)),
+            noise_model=AdaptiveOpticsSim.Tomography.RelativeSignalNoise(
+                TH(0.1)),
             build_backend=build_backend,
         )
         _sync_backend_array!(recon.reconstructor)

--- a/scripts/gpu_profile_model_tomography_phases_contract.jl
+++ b/scripts/gpu_profile_model_tomography_phases_contract.jl
@@ -1,3 +1,5 @@
+using AdaptiveOpticsSim.Tomography
+
 function _sync_backend!(x)
     AdaptiveOpticsSim.Backends.synchronize_backend!(AdaptiveOpticsSim.Backends.execution_style(x))
     return x
@@ -62,10 +64,12 @@ function run_gpu_model_tomography_phase_profile(::Type{B}) where {B<:AdaptiveOpt
         n_actuators=fill(grid_side, n_dm),
         valid_actuators=trues(grid_side, grid_side),
     )
-    noise_model = AdaptiveOpticsSim.RelativeSignalNoise(TB(0.1))
+    noise_model = AdaptiveOpticsSim.Tomography.RelativeSignalNoise(TB(0.1))
 
     gamma_single, t_gamma_single = _time_phase() do
-        AdaptiveOpticsSim.sparse_gradient_matrix(AdaptiveOpticsSim.valid_lenslet_support(wfs); over_sampling=2)
+        AdaptiveOpticsSim.Tomography.sparse_gradient_matrix(
+            AdaptiveOpticsSim.Tomography.valid_lenslet_support(wfs);
+            over_sampling=2)
     end
     gamma_base, grid_mask = gamma_single
     gamma, t_blockdiag = _time_phase() do
@@ -73,24 +77,29 @@ function run_gpu_model_tomography_phase_profile(::Type{B}) where {B<:AdaptiveOpt
     end
 
     cxx, t_cxx = _time_phase() do
-        value = AdaptiveOpticsSim.auto_correlation(build_backend, atmosphere, asterism, wfs, grid_mask)
+        value = AdaptiveOpticsSim.Tomography.auto_correlation(
+            build_backend, atmosphere, asterism, wfs, grid_mask)
         _sync_backend!(value)
     end
     cross, t_cross = _time_phase() do
-        value = AdaptiveOpticsSim.cross_correlation(build_backend, atmosphere, asterism, wfs, tomography)
+        value = AdaptiveOpticsSim.Tomography.cross_correlation(
+            build_backend, atmosphere, asterism, wfs, tomography)
         _sync_backend!(value)
     end
 
-    weights = AdaptiveOpticsSim._equal_fit_source_weights(tomography)
+    weights = AdaptiveOpticsSim.Tomography._equal_fit_source_weights(
+        tomography)
     cox_full, t_fit_average = _time_phase() do
-        value = AdaptiveOpticsSim._fit_source_average(cross, weights)
+        value = AdaptiveOpticsSim.Tomography._fit_source_average(
+            cross, weights)
         _sync_backend!(value)
     end
 
     row_positions = findall(vec(grid_mask))
     col_positions = findall(repeat(vec(grid_mask), asterism.n_lgs))
     cox, t_extract = _time_phase() do
-        value = AdaptiveOpticsSim._extract_submatrix(cox_full, row_positions, col_positions, build_backend)
+        value = AdaptiveOpticsSim.Tomography._extract_submatrix(
+            cox_full, row_positions, col_positions, build_backend)
         _sync_backend!(value)
     end
 
@@ -120,7 +129,8 @@ function run_gpu_model_tomography_phase_profile(::Type{B}) where {B<:AdaptiveOpt
         _sync_backend!(value)
     end
     cnz, t_cnz = _time_phase() do
-        value = AdaptiveOpticsSim.tomography_noise_covariance(build_backend, noise_model, diag(css_signal))
+        value = AdaptiveOpticsSim.Tomography.tomography_noise_covariance(
+            build_backend, noise_model, diag(css_signal))
         _sync_backend!(value)
     end
     css, t_css = _time_phase() do
@@ -133,11 +143,14 @@ function run_gpu_model_tomography_phase_profile(::Type{B}) where {B<:AdaptiveOpt
         _sync_backend!(value)
     end
     recstat, t_recstat = _time_phase() do
-        value = AdaptiveOpticsSim.stable_hermitian_right_division(build_backend, rhs, css)
+        value =
+            AdaptiveOpticsSim.Tomography.stable_hermitian_right_division(
+                build_backend, rhs, css)
         _sync_backend!(value)
     end
 
-    d = AdaptiveOpticsSim.support_diameter(wfs) / size(AdaptiveOpticsSim.valid_lenslet_support(wfs), 1)
+    d = AdaptiveOpticsSim.Tomography.support_diameter(wfs) /
+        size(AdaptiveOpticsSim.Tomography.valid_lenslet_support(wfs), 1)
     wavefront_to_meter = asterism.wavelength / d / 2
     recon, t_recon = _time_phase() do
         value = d * wavefront_to_meter .* recstat

--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -422,25 +422,9 @@ import .WavefrontSensors:
 include("plant/plant.jl")
 include("calibration/calibration.jl")
 
-# Tomography still awaits its namespace gate. Import only the calibration
-# identities its flat implementation consumes; these are package-internal
-# composition bindings, not root exports or public API.
-import .Calibration:
-    BuildBackend,
-    CPUBuildBackend,
-    GPUArrayBuildBackend,
-    InteractionMatrix,
-    NativeBuildBackend,
-    default_build_backend,
-    materialize_build,
-    prepare_build_matrix
-
 include("control/control.jl")
 include("control/ensemble.jl")
-include("tomography/parameters.jl")
-include("tomography/geometry.jl")
-include("tomography/fitting.jl")
-include("tomography/reconstructors.jl")
+include("tomography/tomography.jl")
 
 include("exports.jl")
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -8,7 +8,7 @@
 export AdaptiveOpticsSimError, InvalidConfiguration, DimensionMismatchError
 export UnsupportedAlgorithm, NumericalConditionError
 export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Calibration
-export Control, Plant
+export Control, Tomography, Plant
 
 export FidelityProfile, ScientificProfile, FastProfile, default_fidelity_profile
 export runtime_rng, deterministic_reference_rng
@@ -22,12 +22,3 @@ export runtime_timing
 public run_ensemble!, ensemble_members, execution_policy
 public ensemble_ownership_roots, init_ensemble_scheduler, execute_ensemble!
 public init_execution_state
-
-export TomographyAtmosphereParams, LGSAsterismParams, LGSWFSParams
-export TomographyParams, TomographyDMParams
-export ModelBasedTomography, InteractionMatrixTomography
-export SimulationSlopes, InterleavedSlopes, InvertedSlopes
-export build_reconstructor, assemble_reconstructor_and_fitting
-export zenith_angle_deg, wind_direction_deg
-export reconstruct_wavefront_map
-export dm_commands

--- a/src/tomography/api.jl
+++ b/src/tomography/api.jl
@@ -1,0 +1,7 @@
+export TomographyAtmosphereParams, LGSAsterismParams, LGSWFSParams
+export TomographyParams, TomographyDMParams
+export ModelBasedTomography, InteractionMatrixTomography
+export SimulationSlopes, InterleavedSlopes, InvertedSlopes
+export build_reconstructor, assemble_reconstructor_and_fitting
+export zenith_angle_deg, wind_direction_deg
+export reconstruct_wavefront_map, dm_commands

--- a/src/tomography/tomography.jl
+++ b/src/tomography/tomography.jl
@@ -1,0 +1,56 @@
+"""
+    Tomography
+
+Canonical owner of guide-star geometry, atmospheric tomography models,
+tomographic reconstruction, fitting, and DM-command projection.
+"""
+module Tomography
+
+using KernelAbstractions
+using LinearAlgebra
+using SparseArrays
+using SpecialFunctions
+
+import ..AdaptiveOpticsSim:
+    DimensionMismatchError,
+    InvalidConfiguration,
+    UnsupportedAlgorithm,
+    _scaled_kv56_cpu,
+    _scaled_kv56_scalar
+
+import ..Backends:
+    AcceleratorStyle,
+    ScalarCPUStyle,
+    backend_matmul_transpose_right,
+    backend_symmetric_product,
+    execution_style,
+    launch_kernel_async!
+
+import ..Optics:
+    DeformableMirror
+
+import ..Detectors:
+    Detector,
+    readout_noise
+
+import ..WavefrontSensors:
+    n_valid_subapertures
+
+import ..Calibration:
+    BuildBackend,
+    CPUBuildBackend,
+    GPUArrayBuildBackend,
+    InteractionMatrix,
+    NativeBuildBackend,
+    _backend_array,
+    default_build_backend,
+    materialize_build,
+    prepare_build_matrix
+
+include("parameters.jl")
+include("geometry.jl")
+include("fitting.jl")
+include("reconstructors.jl")
+include("api.jl")
+
+end # module Tomography

--- a/test/amdgpu/extension_coverage.jl
+++ b/test/amdgpu/extension_coverage.jl
@@ -112,7 +112,7 @@ AMDGPU.functional() ||
     end
 
     gram_host = Float32[2 0; 0 4]
-    division = AdaptiveOpticsSim.stable_hermitian_right_division(
+    division = AdaptiveOpticsSim.Tomography.stable_hermitian_right_division(
         build_backend,
         AMDGPU.ROCArray(left_host),
         AMDGPU.ROCArray(gram_host),

--- a/test/backend_optional_common.jl
+++ b/test/backend_optional_common.jl
@@ -2793,7 +2793,7 @@ function run_optional_scalable_reconstructor_checks(::Type{T}, selector,
     @test all(isfinite, Array(factorized_out))
     @test all(storage -> storage isa BackendArray,
         Control.runtime_reconstructor_storage(controlled))
-    @test AdaptiveOpticsSim.reset_controller!(controlled) === controlled
+    @test Control.reset_controller!(controlled) === controlled
     @test_throws InvalidConfiguration ControlledReconstructor(
         factorized,
         DiscreteIntegratorController(n_commands; T=T, backend=CPUBackend());

--- a/test/contracts/namespace_migration_state.toml
+++ b/test/contracts/namespace_migration_state.toml
@@ -2,8 +2,8 @@ schema_version = 1
 name = "namespace_migration_state"
 status = "maintained"
 authority = "namespace_authority.toml"
-current_gate = "NS-07B"
-implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration", "Control"]
+current_gate = "NS-08"
+implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration", "Control", "Tomography"]
 partial_owners = ["WavefrontSensors"]
 
 [owner_sources]
@@ -13,6 +13,7 @@ Detectors = "src/detectors/api.jl"
 Atmospheres = "src/atmosphere/api.jl"
 Calibration = "src/calibration/api.jl"
 Control = "src/control/api.jl"
+Tomography = "src/tomography/api.jl"
 
 [partial_owner_sources]
 WavefrontSensors = "src/wfs/api.jl"

--- a/test/ka_cpu_matrix.jl
+++ b/test/ka_cpu_matrix.jl
@@ -91,7 +91,8 @@ end
         diagonal_input = reshape(collect(1.0:16.0), 4, 4)
         diagonal_output = zeros(4)
         AdaptiveOpticsSim.Backends.launch_kernel!(KA_CPU_STYLE,
-            AdaptiveOpticsSim.extract_diagonal_kernel!, diagonal_output,
+            AdaptiveOpticsSim.Tomography.extract_diagonal_kernel!,
+            diagonal_output,
             diagonal_input, 4; ndrange=4)
         mark_ka_cpu_kernel!(:extract_diagonal_kernel!)
         @test diagonal_output == diag(diagonal_input)

--- a/test/ka_cpu_runtests.jl
+++ b/test/ka_cpu_runtests.jl
@@ -6,6 +6,7 @@ using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Tomography
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using FFTW
@@ -65,6 +66,14 @@ for name in names(WavefrontSensors; all=true)
             !isdefined(@__MODULE__, name)
         @eval const $(name) =
             getfield(WavefrontSensors, $(QuoteNode(name)))
+    end
+end
+
+for name in names(Tomography; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) = getfield(Tomography, $(QuoteNode(name)))
     end
 end
 

--- a/test/runtests_gpu_target_common.jl
+++ b/test/runtests_gpu_target_common.jl
@@ -6,6 +6,9 @@ using AdaptiveOpticsSim.Backends
 using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
+using AdaptiveOpticsSim.Calibration
+using AdaptiveOpticsSim.Control
+using AdaptiveOpticsSim.Tomography
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra

--- a/test/runtests_head.jl
+++ b/test/runtests_head.jl
@@ -8,6 +8,7 @@ using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
+using AdaptiveOpticsSim.Tomography
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra
@@ -96,6 +97,14 @@ for name in names(Control; all=true)
     if Base.isidentifier(s) && !startswith(s, "#") &&
             !isdefined(@__MODULE__, name)
         @eval const $(name) = getfield(Control, $(QuoteNode(name)))
+    end
+end
+
+for name in names(Tomography; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) = getfield(Tomography, $(QuoteNode(name)))
     end
 end
 

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -462,6 +462,31 @@ end
         @test Base.ispublic(Control, name)
         @test parentmodule(getfield(Control, name)) === Control
     end
+    for name in (
+        :TomographyAtmosphereParams,
+        :LGSAsterismParams,
+        :LGSWFSParams,
+        :TomographyParams,
+        :TomographyDMParams,
+        :ModelBasedTomography,
+        :InteractionMatrixTomography,
+        :SimulationSlopes,
+        :InterleavedSlopes,
+        :InvertedSlopes,
+        :build_reconstructor,
+        :assemble_reconstructor_and_fitting,
+        :zenith_angle_deg,
+        :wind_direction_deg,
+        :reconstruct_wavefront_map,
+        :dm_commands,
+    )
+        @test !Base.isexported(AdaptiveOpticsSim, name)
+        @test !Base.ispublic(AdaptiveOpticsSim, name)
+        @test !isdefined(AdaptiveOpticsSim, name)
+        @test Base.isexported(Tomography, name)
+        @test Base.ispublic(Tomography, name)
+        @test parentmodule(getfield(Tomography, name)) === Tomography
+    end
     @test !Base.isexported(AdaptiveOpticsSim, :ensemble_ownership_roots)
     @test !Base.isexported(AdaptiveOpticsSim, :run_ensemble!)
     @test !Base.isexported(AdaptiveOpticsSim, :CUDABackendTag)

--- a/test/testsets/namespace_authority.jl
+++ b/test/testsets/namespace_authority.jl
@@ -119,6 +119,8 @@ function adaptive_optics_sim_extension_hooks(path::AbstractString)
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Calibration\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
         "Control" =>
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Control\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
+        "Tomography" =>
+            r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Tomography\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
     )
     owners = Dict{String,String}()
     for (owner, pattern) in patterns

--- a/test/tomography.jl
+++ b/test/tomography.jl
@@ -132,8 +132,11 @@ end
     expected = (recon.operators.cox * transpose(imat)) / Matrix(imat * recon.operators.cxx * transpose(imat) .+ recon.operators.cnz) * slopes
     @test reconstruct_wavefront(recon, slopes) ≈ expected
     out = zeros(1)
-    reconstruct_wavefront!(out, recon, slopes)
+    @test @inferred(reconstruct_wavefront!(out, recon, slopes)) === out
     @test out ≈ expected
+    if !coverage_instrumented()
+        @test @allocated(reconstruct_wavefront!(out, recon, slopes)) == 0
+    end
     mapped = reconstruct_wavefront_map(recon, slopes)
     @test size(mapped) == (1, 1)
     @test mapped[1, 1] ≈ expected[1]
@@ -305,6 +308,14 @@ end
     @test cmd_recon_cpu.matrix isa Matrix
     commands = dm_commands(cmd_recon, [0.1, -0.2])
     @test length(commands) == count(dm.valid_actuators)
+    command_out = similar(commands)
+    command_input = [0.1, -0.2]
+    @test @inferred(dm_commands!(command_out, cmd_recon, command_input)) ===
+        command_out
+    if !coverage_instrumented()
+        @test @allocated(dm_commands!(
+            command_out, cmd_recon, command_input)) == 0
+    end
     original = copy(cmd_recon.matrix)
     mask_actuators!(cmd_recon, 1)
     @test all(iszero, @view cmd_recon.matrix[1, :])


### PR DESCRIPTION
Closes #152

## Summary

- establish `AdaptiveOpticsSim.Tomography` as the single authoritative owner of guide-star geometry, atmospheric tomography, fitting, and DM-command projection
- remove the superseded root compatibility surface and migrate package callers, examples, benchmarks, profiling scripts, and accelerator contracts to the canonical module
- move the AMDGPU Hermitian solve extension seam to `Tomography`
- add exact namespace-authority, inference, and warmed allocation contracts
- update maintained API, architecture, extension, tutorial, user, and roadmap documentation

No tomography algorithms or numerical formulas are changed by this ownership gate.

## Local validation

- `Pkg.test(["tomography", "namespace-authority", "core-optics"])`: pass
- `Pkg.test(["ka-cpu", "reference-tutorials", "quality", "backend-smoke"])`: pass (2 expected-broken tutorial checks)
- AMDGPU extension coverage: 39/39 pass
- AMDGPU full target: 967 checks passed before exposing one stale root-qualified test caller; no numerical or device failure
- corrected AMDGPU scalable-reconstructor/controller contract: 9/9 pass
- CUDA full hardware target at exact commit `1355e4c`: 958/958 pass
- static stale-root scan and `git diff --check`: pass

## Review

Published-diff self-review completed with no actionable findings.

## Review focus

- exact Tomography export authority and absence from the package root
- dependency direction (`Backends`/`Optics`/`Detectors`/`WavefrontSensors`/`Calibration` → `Tomography`)
- AMDGPU extension ownership
- unchanged single-/multi-direction and single-/multi-conjugate numerical behavior