### PR TITLE
NS-09: establish Ensembles namespace authority

### DIFF
--- a/benchmarks/benchmark_ensemble_schedulers.jl
+++ b/benchmarks/benchmark_ensemble_schedulers.jl
@@ -1,5 +1,6 @@
 using AcceleratedKernels
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.Ensembles
 using AdaptiveOpticsSim.Backends
 using Dagger
 using LinearAlgebra
@@ -35,7 +36,7 @@ function measure_scheduler(policy, members::Int, resolution::Int;
     warmup::Int, samples::Int)
     ensemble = make_ensemble(policy, members, resolution)
     for _ in 1:warmup
-        AdaptiveOpticsSim.run_ensemble!(
+        Ensembles.run_ensemble!(
             step_closed_loop_workload!,
             ensemble,
         )
@@ -44,13 +45,13 @@ function measure_scheduler(policy, members::Int, resolution::Int;
     latencies_ns = Vector{UInt64}(undef, samples)
     @inbounds for i in eachindex(latencies_ns)
         start_ns = time_ns()
-        AdaptiveOpticsSim.run_ensemble!(
+        Ensembles.run_ensemble!(
             step_closed_loop_workload!,
             ensemble,
         )
         latencies_ns[i] = time_ns() - start_ns
     end
-    allocated_bytes = @allocated AdaptiveOpticsSim.run_ensemble!(
+    allocated_bytes = @allocated Ensembles.run_ensemble!(
         step_closed_loop_workload!,
         ensemble,
     )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,15 +18,16 @@ by `using AdaptiveOpticsSim.Detectors`, atmosphere vocabulary imported by
 `using AdaptiveOpticsSim.Atmospheres`, calibration vocabulary imported by
 `using AdaptiveOpticsSim.Calibration`, control vocabulary imported by
 `using AdaptiveOpticsSim.Control`, tomography vocabulary imported by
-`using AdaptiveOpticsSim.Tomography`, the routine plant workflow imported by
-`using AdaptiveOpticsSim.Plant`, and stable qualified APIs addressed through
+`using AdaptiveOpticsSim.Tomography`, coarse offline execution vocabulary
+imported by `using AdaptiveOpticsSim.Ensembles`, the routine plant workflow
+imported by `using AdaptiveOpticsSim.Plant`, and stable qualified APIs addressed through
 their canonical modules. Qualified public names are maintained but do not
 enter the caller's ordinary namespace. The root package exports the canonical
 modules, not compatibility exports for their moved contents.
 
 The breaking namespace migration is in progress. `Backends`, `Optics`,
-`Atmospheres`, `Detectors`, `Calibration`, `Control`, and `Tomography` are
-complete. `Atmospheres` owns atmosphere
+`Atmospheres`, `Detectors`, `Calibration`, `Control`, `Tomography`, and
+`Ensembles` are complete. `Atmospheres` owns atmosphere
 models and state, source-direction rendering and batching, and
 atmosphere-coupled propagation. `Detectors` owns both conventional frame/area
 and counting/channel sensor APIs. `Optics` owns
@@ -1410,11 +1411,13 @@ the canonical representation of these results.
 - WFS preparation helper: `prepare_runtime_wfs!` prepares the retained WFS
   family-specific scratch required by explicit model loops
 - Generic timing helper: `runtime_timing`
+- Coarse offline execution is imported explicitly with
+  `using AdaptiveOpticsSim.Ensembles`
 - Execution policies: `AbstractExecutionPolicy`, `SequentialExecution`,
   `ThreadedExecution`, `BackendStreamExecution`, `DeterministicExecution`,
   `AcceleratedKernelsExecution`, and `DaggerExecution`
 - Coarse independent work: `SimulationEnsemble`; qualified access through
-  `AdaptiveOpticsSim.run_ensemble!`, `ensemble_members`,
+  `Ensembles.run_ensemble!`, `ensemble_members`,
   `execution_policy`, `ensemble_ownership_roots`,
   `init_ensemble_scheduler`, and `execute_ensemble!`
 

--- a/docs/deterministic-simulation.md
+++ b/docs/deterministic-simulation.md
@@ -136,7 +136,8 @@ for the still-planned addressable multi-device random domain.
   `Plant.deterministic_cpu_execution_budget()` and validate it against an
   explicit `Plant.CPUExecutionEnvironment` before the run. Validation records
   and checks configuration; it does not change process-global thread settings.
-- Use `DeterministicExecution()` for a `SimulationEnsemble`. It rejects a
+- Import `AdaptiveOpticsSim.Ensembles`, then use
+  `DeterministicExecution()` for a `SimulationEnsemble`. It rejects a
   multi-threaded Julia process and configures BLAS and the FFT provider for one
   thread before execution.
 - Keep detector noise disabled for deterministic baseline comparisons unless

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -33,21 +33,23 @@ The owner categories are:
 - `Ensembles` for optional coarse scheduler execution
 - the root package only for cross-domain config and telemetry serialization
 
-Implemented domain owners, including `Backends`, `Optics`, and `Tomography`,
-receive extension methods at `AdaptiveOpticsSim.Owner.name`; no root-package
-forwarding generic remains part of the supported API. In particular,
+Implemented domain owners, including `Backends`, `Optics`, `Tomography`, and
+`Ensembles`, receive extension methods at `AdaptiveOpticsSim.Owner.name`; no
+root-package forwarding generic remains part of the supported API. In particular,
 tomography-specific Hermitian solvers extend
-`AdaptiveOpticsSim.Tomography.stable_hermitian_right_division`. Hooks assigned
-to later domain owners remain at
-`AdaptiveOpticsSim.name` only until that owner's PR moves the generic and every
-extension method together. The maintained stage is recorded in
+`AdaptiveOpticsSim.Tomography.stable_hermitian_right_division`. Scheduler
+extensions likewise extend
+`AdaptiveOpticsSim.Ensembles.init_ensemble_scheduler` and
+`AdaptiveOpticsSim.Ensembles.execute_ensemble!`. The maintained stage is
+recorded in
 [`../test/contracts/namespace_migration_state.toml`](../test/contracts/namespace_migration_state.toml).
 
 ## Source Layout
 
 Use lower-case directory names for new source-tree locations. Julia type names
 may use CamelCase, but package directories should remain lower-case subsystem
-names such as `src/wfs`, `src/detectors`, `src/optics`, or `src/control`.
+names such as `src/wfs`, `src/detectors`, `src/optics`, `src/control`, or
+`src/ensembles`.
 
 ## Plant Model Definitions
 
@@ -852,6 +854,8 @@ roots by default.
 
 ## Ensemble Scheduling
 
+Import this domain with `using AdaptiveOpticsSim.Ensembles`.
+
 `SimulationEnsemble` schedules independent model boundaries at coarse
 granularity. Keep it outside an external-RTC HIL loop: the Plant event loop and
 its single-writer owners must not acquire task-creation or task-graph jitter.
@@ -878,7 +882,8 @@ outweigh gains on small local workloads.
 
 Ensemble construction rejects shared mutable ownership. A mutable member owns
 itself by default. An immutable or mutable wrapper around shared state should
-implement `AdaptiveOpticsSim.ensemble_ownership_roots(wrapper)` and return the
+implement
+`AdaptiveOpticsSim.Ensembles.ensemble_ownership_roots(wrapper)` and return the
 mutable plant/state objects that cannot safely be updated by another member at
 the same time. Immutable values with no mutable owners, such as scalar sweep
 points, require no extension. The scheduler operation passed to

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -94,7 +94,8 @@ policy, interaction/control matrices, modal basis construction, model-derived
 NCPA synthesis, fitting, optical-gain calibration, and registration
 identification. `Control` owns reconstruction and controller composition;
 `Tomography` owns guide-star geometry, atmospheric reconstruction, fitting,
-and DM-command projection; `Ensembles` follows in dependency order. The
+and DM-command projection. `Ensembles` owns coarse offline execution policies,
+sweeps, and optional scheduler integrations. The
 authoritative pre-migration inventory, final exact API allowlists,
 extension-hook owners, and cross-module imports are frozen in
 [`../test/contracts/namespace_authority.toml`](../test/contracts/namespace_authority.toml).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -307,7 +307,8 @@ These contracts contain no implementation binding moves.
 The maintained implementation stage lives in
 [`namespace_migration_state.toml`](../test/contracts/namespace_migration_state.toml);
 `Backends`, `Optics`, `Atmospheres`, `Detectors`, `WavefrontSensors`,
-`Calibration`, `Control`, and `Tomography` are complete through NS-08.
+`Calibration`, `Control`, `Tomography`, and `Ensembles` are complete through
+NS-09.
 `Atmospheres` owns atmosphere models and state, direction rendering and
 batching, and atmosphere-coupled propagation.
 `Detectors` owns both conventional frame/area and counting/channel APIs.
@@ -319,7 +320,8 @@ physical WFS components without changing the frozen final ownership target.
 model-derived calibration products and synthesis, and `Control` owns
 slopes-to-command reconstruction and controller composition. `Tomography`
 owns guide-star geometry, atmospheric reconstruction, fitting, and DM-command
-projection.
+projection. `Ensembles` owns coarse offline execution policies and optional
+parallel scheduler integrations.
 
 ### Ownership target
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -110,8 +110,8 @@ Model-specific `prepare!`, `step!`, and `readout` methods are appropriate when
 the composition is stable, as in the Subaru AO188/AO3k example modules. They do
 not define a second generic package runtime.
 
-`SimulationEnsemble` may schedule several independent model instances for
-coarse offline work.
+After `using AdaptiveOpticsSim.Ensembles`, `SimulationEnsemble` may schedule
+several independent model instances for coarse offline work.
 
 ### 3. Plant execution layer
 

--- a/examples/support/subaru_ao188_simulation.jl
+++ b/examples/support/subaru_ao188_simulation.jl
@@ -8,12 +8,13 @@ using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
+using AdaptiveOpticsSim.Ensembles
 using LinearAlgebra
 using Random
 using Statistics
 
-import AdaptiveOpticsSim: runtime_timing,
-    bin2d!, init_execution_state
+import AdaptiveOpticsSim: runtime_timing, bin2d!
+import AdaptiveOpticsSim.Ensembles: init_execution_state
 import AdaptiveOpticsSim.Calibration: BuildBackend, CPUBuildBackend,
     GPUArrayBuildBackend, NativeBuildBackend, materialize_build
 import AdaptiveOpticsSim.Backends: execution_style, synchronize_backend!

--- a/ext/AdaptiveOpticsSimAcceleratedKernelsExt.jl
+++ b/ext/AdaptiveOpticsSimAcceleratedKernelsExt.jl
@@ -1,14 +1,15 @@
 module AdaptiveOpticsSimAcceleratedKernelsExt
 
 using AdaptiveOpticsSim
+import AdaptiveOpticsSim: Ensembles
 import AcceleratedKernels
 
 struct AcceleratedKernelsSchedulerState{TP}
     partitioner::TP
 end
 
-function AdaptiveOpticsSim.init_ensemble_scheduler(
-    policy::AdaptiveOpticsSim.AcceleratedKernelsExecution,
+function Ensembles.init_ensemble_scheduler(
+    policy::Ensembles.AcceleratedKernelsExecution,
     members::Tuple,
 )
     partitioner = AcceleratedKernels.TaskPartitioner(
@@ -19,21 +20,21 @@ function AdaptiveOpticsSim.init_ensemble_scheduler(
     return AcceleratedKernelsSchedulerState(partitioner)
 end
 
-function AdaptiveOpticsSim.execute_ensemble!(
-    ::AdaptiveOpticsSim.AcceleratedKernelsExecution,
+function Ensembles.execute_ensemble!(
+    ::Ensembles.AcceleratedKernelsExecution,
     state::AcceleratedKernelsSchedulerState,
     f!,
     members::Tuple,
 )
     if length(state.partitioner) == 1
         @inbounds for i in eachindex(members)
-            AdaptiveOpticsSim._run_ensemble_member!(f!, members[i])
+            Ensembles._run_ensemble_member!(f!, members[i])
         end
         return members
     end
     AcceleratedKernels.task_partition(state.partitioner) do member_indices
         @inbounds for i in member_indices
-            AdaptiveOpticsSim._run_ensemble_member!(f!, members[i])
+            Ensembles._run_ensemble_member!(f!, members[i])
         end
     end
     return members

--- a/ext/AdaptiveOpticsSimDaggerExt.jl
+++ b/ext/AdaptiveOpticsSimDaggerExt.jl
@@ -1,39 +1,40 @@
 module AdaptiveOpticsSimDaggerExt
 
 using AdaptiveOpticsSim
+import AdaptiveOpticsSim: Ensembles
 import Dagger
 
 struct DaggerSchedulerState end
 
-AdaptiveOpticsSim.init_ensemble_scheduler(
-    ::AdaptiveOpticsSim.DaggerExecution,
+Ensembles.init_ensemble_scheduler(
+    ::Ensembles.DaggerExecution,
     ::Tuple,
 ) = DaggerSchedulerState()
 
 @inline function _spawn_member(
-    ::AdaptiveOpticsSim.DaggerExecution{Nothing},
+    ::Ensembles.DaggerExecution{Nothing},
     f!,
     member,
 )
-    return Dagger.spawn(AdaptiveOpticsSim._run_ensemble_member!, f!, member)
+    return Dagger.spawn(Ensembles._run_ensemble_member!, f!, member)
 end
 
 @inline function _spawn_member(
-    policy::AdaptiveOpticsSim.DaggerExecution,
+    policy::Ensembles.DaggerExecution,
     f!,
     member,
 )
     options = Dagger.Options(; scope=policy.scope)
     return Dagger.spawn(
-        AdaptiveOpticsSim._run_ensemble_member!,
+        Ensembles._run_ensemble_member!,
         options,
         f!,
         member,
     )
 end
 
-function AdaptiveOpticsSim.execute_ensemble!(
-    policy::AdaptiveOpticsSim.DaggerExecution,
+function Ensembles.execute_ensemble!(
+    policy::Ensembles.DaggerExecution,
     ::DaggerSchedulerState,
     f!,
     members::Tuple,

--- a/scripts/profile_pixel_output_runtime.jl
+++ b/scripts/profile_pixel_output_runtime.jl
@@ -1,4 +1,5 @@
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.Ensembles
 using AdaptiveOpticsSim.Backends
 using Random
 

--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -220,9 +220,9 @@ include("core/types.jl")
 include("core/config.jl")
 include("core/kv56.jl")
 include("core/workspace.jl")
-include("core/parallel.jl")
 include("core/telemetry.jl")
 
+include("ensembles/ensembles.jl")
 include("atmosphere/atmospheres.jl")
 
 # Atmosphere implementations have one authoritative owner. Root composition
@@ -423,7 +423,6 @@ include("plant/plant.jl")
 include("calibration/calibration.jl")
 
 include("control/control.jl")
-include("control/ensemble.jl")
 include("tomography/tomography.jl")
 
 include("exports.jl")

--- a/src/ensembles/api.jl
+++ b/src/ensembles/api.jl
@@ -1,0 +1,8 @@
+export AbstractExecutionPolicy
+export SequentialExecution, ThreadedExecution, BackendStreamExecution
+export DeterministicExecution, AcceleratedKernelsExecution, DaggerExecution
+export SimulationEnsemble
+
+public run_ensemble!, ensemble_members, execution_policy
+public ensemble_ownership_roots, init_ensemble_scheduler, execute_ensemble!
+public init_execution_state

--- a/src/ensembles/ensembles.jl
+++ b/src/ensembles/ensembles.jl
@@ -1,0 +1,22 @@
+"""
+    Ensembles
+
+Canonical owner of execution policies and coarse-grained orchestration for
+independent offline simulations, sweeps, and calibration work.
+"""
+module Ensembles
+
+using LinearAlgebra
+
+import ..AdaptiveOpticsSim:
+    InvalidConfiguration,
+    UnsupportedAlgorithm
+
+import ..Backends:
+    set_fft_provider_threads!
+
+include("execution_policies.jl")
+include("simulation_ensemble.jl")
+include("api.jl")
+
+end # module Ensembles

--- a/src/ensembles/execution_policies.jl
+++ b/src/ensembles/execution_policies.jl
@@ -1,3 +1,4 @@
+# Execution policies for coarse offline orchestration.
 abstract type AbstractExecutionPolicy end
 
 """

--- a/src/ensembles/simulation_ensemble.jl
+++ b/src/ensembles/simulation_ensemble.jl
@@ -1,3 +1,4 @@
+# Coarse independent simulation ensembles.
 """
     SimulationEnsemble(members...; policy=SequentialExecution())
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -8,17 +8,9 @@
 export AdaptiveOpticsSimError, InvalidConfiguration, DimensionMismatchError
 export UnsupportedAlgorithm, NumericalConditionError
 export Backends, Optics, Detectors, Atmospheres, WavefrontSensors, Calibration
-export Control, Tomography, Plant
+export Control, Tomography, Ensembles, Plant
 
 export FidelityProfile, ScientificProfile, FastProfile, default_fidelity_profile
 export runtime_rng, deterministic_reference_rng
 
-export AbstractExecutionPolicy
-export SequentialExecution, ThreadedExecution, BackendStreamExecution
-export DeterministicExecution, AcceleratedKernelsExecution, DaggerExecution
-export SimulationEnsemble
 export runtime_timing
-
-public run_ensemble!, ensemble_members, execution_policy
-public ensemble_ownership_roots, init_ensemble_scheduler, execute_ensemble!
-public init_execution_state

--- a/test/contracts/namespace_migration_state.toml
+++ b/test/contracts/namespace_migration_state.toml
@@ -2,8 +2,8 @@ schema_version = 1
 name = "namespace_migration_state"
 status = "maintained"
 authority = "namespace_authority.toml"
-current_gate = "NS-08"
-implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration", "Control", "Tomography"]
+current_gate = "NS-09"
+implemented_owners = ["Backends", "Optics", "Detectors", "Atmospheres", "Calibration", "Control", "Tomography", "Ensembles"]
 partial_owners = ["WavefrontSensors"]
 
 [owner_sources]
@@ -14,6 +14,7 @@ Atmospheres = "src/atmosphere/api.jl"
 Calibration = "src/calibration/api.jl"
 Control = "src/control/api.jl"
 Tomography = "src/tomography/api.jl"
+Ensembles = "src/ensembles/api.jl"
 
 [partial_owner_sources]
 WavefrontSensors = "src/wfs/api.jl"
@@ -241,13 +242,16 @@ internal = [
 [baseline_divergence]
 root_surface = "src/exports.jl"
 extension_sources = [
+    "ext/AdaptiveOpticsSimAcceleratedKernelsExt.jl",
     "ext/AdaptiveOpticsSimAMDGPUExt.jl",
     "ext/AdaptiveOpticsSimAppleAccelerateExt.jl",
     "ext/AdaptiveOpticsSimCUDAExt.jl",
+    "ext/AdaptiveOpticsSimDaggerExt.jl",
     "ext/AdaptiveOpticsSimMetalExt.jl",
 ]
 extension_tests = [
     "test/appleaccelerate/backend_neutral.jl",
     "test/optional_amdgpu_backends.jl",
     "test/optional_cuda_backends.jl",
+    "test/schedulers/runtests.jl",
 ]

--- a/test/ka_cpu_runtests.jl
+++ b/test/ka_cpu_runtests.jl
@@ -7,6 +7,7 @@ using AdaptiveOpticsSim.Detectors
 using AdaptiveOpticsSim.Atmospheres
 using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Tomography
+using AdaptiveOpticsSim.Ensembles
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using FFTW
@@ -74,6 +75,14 @@ for name in names(Tomography; all=true)
     if Base.isidentifier(s) && !startswith(s, "#") &&
             !isdefined(@__MODULE__, name)
         @eval const $(name) = getfield(Tomography, $(QuoteNode(name)))
+    end
+end
+
+for name in names(Ensembles; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) = getfield(Ensembles, $(QuoteNode(name)))
     end
 end
 

--- a/test/runtests_gpu_target_common.jl
+++ b/test/runtests_gpu_target_common.jl
@@ -9,6 +9,7 @@ using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
 using AdaptiveOpticsSim.Tomography
+using AdaptiveOpticsSim.Ensembles
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra

--- a/test/runtests_head.jl
+++ b/test/runtests_head.jl
@@ -9,6 +9,7 @@ using AdaptiveOpticsSim.WavefrontSensors
 using AdaptiveOpticsSim.Calibration
 using AdaptiveOpticsSim.Control
 using AdaptiveOpticsSim.Tomography
+using AdaptiveOpticsSim.Ensembles
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
 using LinearAlgebra
@@ -105,6 +106,14 @@ for name in names(Tomography; all=true)
     if Base.isidentifier(s) && !startswith(s, "#") &&
             !isdefined(@__MODULE__, name)
         @eval const $(name) = getfield(Tomography, $(QuoteNode(name)))
+    end
+end
+
+for name in names(Ensembles; all=true)
+    s = String(name)
+    if Base.isidentifier(s) && !startswith(s, "#") &&
+            !isdefined(@__MODULE__, name)
+        @eval const $(name) = getfield(Ensembles, $(QuoteNode(name)))
     end
 end
 

--- a/test/schedulers/runtests.jl
+++ b/test/schedulers/runtests.jl
@@ -1,5 +1,6 @@
 using AcceleratedKernels
 using AdaptiveOpticsSim
+using AdaptiveOpticsSim.Ensembles
 using Dagger
 using Test
 
@@ -23,13 +24,13 @@ increment_ten!(counter::SchedulerCounter) =
             max_tasks=min(4, Threads.nthreads()),
             min_members_per_task=1,
         ))
-    @test AdaptiveOpticsSim.run_ensemble!(increment!, ensemble) === ensemble
+    @test Ensembles.run_ensemble!(increment!, ensemble) === ensemble
     @test all(counter -> counter.count == 1,
-        AdaptiveOpticsSim.ensemble_members(ensemble))
-    @test AdaptiveOpticsSim.run_ensemble!(increment_ten!, ensemble) ===
+        Ensembles.ensemble_members(ensemble))
+    @test Ensembles.run_ensemble!(increment_ten!, ensemble) ===
         ensemble
     @test all(counter -> counter.count == 11,
-        AdaptiveOpticsSim.ensemble_members(ensemble))
+        Ensembles.ensemble_members(ensemble))
 
     single_task = SimulationEnsemble(
         ntuple(_ -> SchedulerCounter(0), 2);
@@ -38,10 +39,10 @@ increment_ten!(counter::SchedulerCounter) =
             min_members_per_task=1,
         ),
     )
-    @test AdaptiveOpticsSim.run_ensemble!(increment!, single_task) ===
+    @test Ensembles.run_ensemble!(increment!, single_task) ===
         single_task
     @test all(counter -> counter.count == 1,
-        AdaptiveOpticsSim.ensemble_members(single_task))
+        Ensembles.ensemble_members(single_task))
 end
 
 @testset "Dagger ensemble extension" begin
@@ -51,20 +52,20 @@ end
     ))
     counters = ntuple(_ -> SchedulerCounter(0), 4)
     ensemble = SimulationEnsemble(counters; policy=DaggerExecution())
-    @test AdaptiveOpticsSim.run_ensemble!(increment!, ensemble) === ensemble
+    @test Ensembles.run_ensemble!(increment!, ensemble) === ensemble
     @test all(counter -> counter.count == 1,
-        AdaptiveOpticsSim.ensemble_members(ensemble))
-    @test AdaptiveOpticsSim.run_ensemble!(increment_ten!, ensemble) ===
+        Ensembles.ensemble_members(ensemble))
+    @test Ensembles.run_ensemble!(increment_ten!, ensemble) ===
         ensemble
     @test all(counter -> counter.count == 11,
-        AdaptiveOpticsSim.ensemble_members(ensemble))
+        Ensembles.ensemble_members(ensemble))
 
     local_scope = Dagger.scope(worker=1)
     scoped = SimulationEnsemble(
         ntuple(_ -> SchedulerCounter(0), 2);
         policy=DaggerExecution(scope=local_scope),
     )
-    @test AdaptiveOpticsSim.run_ensemble!(increment!, scoped) === scoped
+    @test Ensembles.run_ensemble!(increment!, scoped) === scoped
     @test all(counter -> counter.count == 1,
-        AdaptiveOpticsSim.ensemble_members(scoped))
+        Ensembles.ensemble_members(scoped))
 end

--- a/test/testsets/control_primitives.jl
+++ b/test/testsets/control_primitives.jl
@@ -345,11 +345,13 @@ struct ImmutableEnsembleMember
     owner::Base.RefValue{Int}
 end
 
+struct EnsembleMemberError <: Exception end
+
 EnsembleCounter(value::Int=0) = EnsembleCounter(value, Ref(value))
 
-AdaptiveOpticsSim.ensemble_ownership_roots(counter::EnsembleCounter) =
+Ensembles.ensemble_ownership_roots(counter::EnsembleCounter) =
     (counter.owner,)
-AdaptiveOpticsSim.ensemble_ownership_roots(member::ImmutableEnsembleMember) =
+Ensembles.ensemble_ownership_roots(member::ImmutableEnsembleMember) =
     (member.owner,)
 
 function increment_counter!(counter::EnsembleCounter)
@@ -360,15 +362,42 @@ end
 @testset "Generic coarse ensembles" begin
     first_counter = EnsembleCounter()
     second_counter = EnsembleCounter(10)
-    ensemble = SimulationEnsemble(first_counter, second_counter)
-    @test ensemble_members(ensemble) ===
+    ensemble = @inferred SimulationEnsemble(first_counter, second_counter)
+    @test @inferred(ensemble_members(ensemble)) ===
         (first_counter, second_counter)
-    @test execution_policy(ensemble) isa SequentialExecution
-    @test AdaptiveOpticsSim.run_ensemble!(
+    @test @inferred(execution_policy(ensemble)) isa SequentialExecution
+    @test @inferred(Ensembles.run_ensemble!(
         increment_counter!,
         ensemble,
-    ) === ensemble
+    )) === ensemble
     @test (first_counter.value, second_counter.value) == (1, 11)
+    if !coverage_instrumented()
+        @test @allocated(Ensembles.run_ensemble!(
+            increment_counter!, ensemble)) == 0
+    end
+
+    visit_order = Int[]
+    ordered = SimulationEnsemble(
+        EnsembleCounter(1),
+        EnsembleCounter(2),
+        EnsembleCounter(3),
+    )
+    Ensembles.run_ensemble!(
+        member -> (push!(visit_order, member.value); member),
+        ordered,
+    )
+    @test visit_order == [1, 2, 3]
+
+    failing = SimulationEnsemble(
+        EnsembleCounter(1),
+        EnsembleCounter(2),
+        EnsembleCounter(3),
+    )
+    @test_throws EnsembleMemberError Ensembles.run_ensemble!(
+        member -> (member.value == 2 && throw(EnsembleMemberError()); member),
+        failing,
+    )
+    @test map(member -> member.value, ensemble_members(failing)) == (1, 2, 3)
 
     immutable_values = SimulationEnsemble(1, 1)
     @test ensemble_members(immutable_values) === (1, 1)
@@ -378,7 +407,7 @@ end
         EnsembleCounter();
         policy=ThreadedExecution(),
     )
-    AdaptiveOpticsSim.run_ensemble!(increment_counter!, threaded)
+    Ensembles.run_ensemble!(increment_counter!, threaded)
     @test all(counter -> counter.value == 1, ensemble_members(threaded))
 
     shared_owner = Ref(0)
@@ -403,7 +432,7 @@ end
             EnsembleCounter();
             policy=policy,
         )
-        @test_throws UnsupportedAlgorithm AdaptiveOpticsSim.run_ensemble!(
+        @test_throws UnsupportedAlgorithm Ensembles.run_ensemble!(
             increment_counter!,
             unsupported,
         )
@@ -414,7 +443,7 @@ end
             EnsembleCounter();
             policy=DeterministicExecution(),
         )
-        AdaptiveOpticsSim.run_ensemble!(
+        Ensembles.run_ensemble!(
             increment_counter!,
             deterministic,
         )

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -304,12 +304,8 @@ end
         @test Base.ispublic(Detectors, name)
         @test parentmodule(getfield(Detectors, name)) === Detectors
     end
-    @test Base.isexported(AdaptiveOpticsSim, :SimulationEnsemble)
     @test Base.isexported(Control, :FactorizedReconstructor)
     @test Base.isexported(Control, :ControlledReconstructor)
-    @test Base.isexported(AdaptiveOpticsSim, :DeterministicExecution)
-    @test Base.isexported(AdaptiveOpticsSim, :AcceleratedKernelsExecution)
-    @test Base.isexported(AdaptiveOpticsSim, :DaggerExecution)
     @test !Base.isexported(AdaptiveOpticsSim, :PyramidWFS)
     @test !Base.isexported(AdaptiveOpticsSim, :BioEdgeWFS)
     @test Base.isexported(WavefrontSensors, :PyramidWFS)
@@ -487,8 +483,39 @@ end
         @test Base.ispublic(Tomography, name)
         @test parentmodule(getfield(Tomography, name)) === Tomography
     end
-    @test !Base.isexported(AdaptiveOpticsSim, :ensemble_ownership_roots)
-    @test !Base.isexported(AdaptiveOpticsSim, :run_ensemble!)
+    for name in (
+        :AbstractExecutionPolicy,
+        :SequentialExecution,
+        :ThreadedExecution,
+        :BackendStreamExecution,
+        :DeterministicExecution,
+        :AcceleratedKernelsExecution,
+        :DaggerExecution,
+        :SimulationEnsemble,
+    )
+        @test !Base.isexported(AdaptiveOpticsSim, name)
+        @test !Base.ispublic(AdaptiveOpticsSim, name)
+        @test !isdefined(AdaptiveOpticsSim, name)
+        @test Base.isexported(Ensembles, name)
+        @test Base.ispublic(Ensembles, name)
+        @test parentmodule(getfield(Ensembles, name)) === Ensembles
+    end
+    for name in (
+        :run_ensemble!,
+        :ensemble_members,
+        :execution_policy,
+        :ensemble_ownership_roots,
+        :init_ensemble_scheduler,
+        :execute_ensemble!,
+        :init_execution_state,
+    )
+        @test !Base.isexported(AdaptiveOpticsSim, name)
+        @test !Base.ispublic(AdaptiveOpticsSim, name)
+        @test !isdefined(AdaptiveOpticsSim, name)
+        @test !Base.isexported(Ensembles, name)
+        @test Base.ispublic(Ensembles, name)
+        @test parentmodule(getfield(Ensembles, name)) === Ensembles
+    end
     @test !Base.isexported(AdaptiveOpticsSim, :CUDABackendTag)
     @test !Base.isexported(AdaptiveOpticsSim, :MetalBackendTag)
     @test !Base.isexported(AdaptiveOpticsSim, :AMDGPUBackendTag)

--- a/test/testsets/namespace_authority.jl
+++ b/test/testsets/namespace_authority.jl
@@ -121,6 +121,8 @@ function adaptive_optics_sim_extension_hooks(path::AbstractString)
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Control\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
         "Tomography" =>
             r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Tomography\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
+        "Ensembles" =>
+            r"(?m)^(?:@inline\s+)?(?:function\s+)?(?:AdaptiveOpticsSim\.)?Ensembles\.([A-Za-z_][A-Za-z0-9_!]*)\s*(?:\{|\()",
     )
     owners = Dict{String,String}()
     for (owner, pattern) in patterns


### PR DESCRIPTION
Closes #153

## Summary

- establish `AdaptiveOpticsSim.Ensembles` as the single authoritative owner of coarse offline execution policies and `SimulationEnsemble`
- physically relocate execution-policy and ensemble implementation files under `src/ensembles/`
- remove the superseded root bindings and migrate package callers, examples, benchmarks, tests, and maintained documentation
- move AcceleratedKernels and Dagger extension hooks to the canonical owner
- add exact export/public authority plus explicit inference, zero-allocation, serial ordering, and exception-propagation characterization

No scheduling algorithm, task partition, numerical model, device kernel, or HIL deadline behavior changes in this gate.

## Local validation

- namespace authority: 3422/3422
- frozen correctness/performance baseline index: 92/92
- exact API export curation: 1629/1629
- generic coarse ensembles: 18/18
- AcceleratedKernels extension under 4 Julia threads: 7/7
- Dagger extension under 4 Julia threads: 7/7
- native `ThreadedExecution` multi-thread smoke and deterministic multi-thread rejection: pass
- KA CPU matrix: 194/194
- Aqua: 11/11
- OOPAO regression: 49/49
- SPECULA regression: 19/19
- tutorial examples: 51 pass, 2 expected broken
- warmed serial `run_ensemble!`: 0 bytes allocated
- static stale-root scan and `git diff --check`: pass

## Review

Published-diff self-review completed with no actionable findings. GPU hardware validation is not applicable: this gate changes CPU/offline scheduler ownership and extension dispatch, not device kernels or array behavior.

## Review focus

- exact `Ensembles` export/public surface and absence of moved names from the package root
- dependency direction (`Backends` → `Ensembles`)
- AK/Dagger extension hook ownership
- preservation of serial order, threaded behavior, ownership rejection, error propagation, deterministic thread policy, and member result ordering