### PR TITLE
Tier CI validation workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,15 @@
 name: Coverage
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  schedule:
+    - cron: "47 10 * * *"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -13,6 +18,9 @@ permissions:
 jobs:
   shard-coverage:
     name: Shard coverage / ${{ matrix.shard }}
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -50,6 +58,9 @@ jobs:
 
   project-coverage:
     name: Project coverage / full composition
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:

--- a/.github/workflows/cpu-validation.yml
+++ b/.github/workflows/cpu-validation.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  schedule:
+    - cron: "17 9 * * *"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 permissions:
   contents: read
@@ -12,6 +19,9 @@ permissions:
 jobs:
   full-composition:
     name: Full composition / Linux
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -39,6 +49,10 @@ jobs:
 
   fast-feedback:
     name: Fast feedback / ${{ matrix.shard }}
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -75,6 +89,10 @@ jobs:
 
   platform-closure:
     name: Platform closure / ${{ matrix.os }} / ${{ matrix.shard }}
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -114,6 +132,10 @@ jobs:
 
   grouped-cpu-execution:
     name: Grouped CPU execution
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -141,6 +163,10 @@ jobs:
 
   scheduler-extensions:
     name: Optional CPU scheduler extensions
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -166,8 +192,45 @@ jobs:
       - name: Run scheduler extension tests
         run: julia --threads=4 --project=test/schedulers --startup-file=no test/schedulers/runtests.jl
 
+  linux-arm64-portability:
+    name: Linux aarch64 portability
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    env:
+      JULIA_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      OMP_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12"
+
+      - name: Cache Julia artifacts
+        uses: julia-actions/cache@v3
+
+      - name: Verify Linux aarch64 runner
+        run: julia --startup-file=no -e 'using InteractiveUtils; Sys.islinux() && Sys.ARCH === :aarch64 || error("Linux aarch64 validation requires an aarch64 runner"); versioninfo()'
+
+      - name: Instantiate
+        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Run Linux aarch64 portability shard
+        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(test_args=["ci-foundations"])'
+
   apple-accelerate:
     name: Apple Silicon / AppleAccelerate
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
     runs-on: macos-15
     timeout-minutes: 90
     permissions:


### PR DESCRIPTION
## What changed

- cancel superseded pull-request runs in both CPU Validation and Coverage;
- defer the full 21-job hosted matrix while a PR is draft, then run the unchanged matrix on `ready_for_review` and later non-draft updates;
- replace the duplicate post-merge matrix with one full Linux composition job;
- run complete CPU/platform/coverage closure nightly and through explicit dispatch;
- add scheduled/manual Linux aarch64 portability coverage on GitHub's hosted `ubuntu-24.04-arm` runner;
- retain all existing job names, test selectors, tolerances, and accelerator workflows.

## Why

The existing PR plus post-merge workflow consumed roughly 270 aggregate runner-minutes per delivered change and made CI polling part of the development loop. This separates local focused verification from asynchronous delivery evidence without weakening the enforceable review-ready PR surface.

| Event | CPU runner jobs | Coverage runner jobs | Intent |
| --- | ---: | ---: | --- |
| draft PR | 0 | 0 | local development |
| review-ready PR | 16 | 5 | unchanged pre-merge assurance |
| `main` push | 1 | 0 | bounded integration smoke |
| nightly/manual | 17 | 5 | full closure plus Linux aarch64 |

Nightly CPU and Coverage runs are deliberately separate regression-monitoring runs, not atomic release evidence. A release/manual qualification must dispatch both workflows on the intended ref and record the tested SHA.

## Validation

- `actionlint` passed for both modified workflows.
- Python structural/event-matrix assertions passed.
- Local Julia 1.12.6: `Pkg.test(test_args=["ci-foundations"])` passed.
- Raspberry Pi 5, Linux aarch64, Julia 1.12.6: the same fresh selector passed from an isolated temporary checkout in 28.6 seconds.
- Independent read-only workflow review confirmed event counts, concurrency groups, status names, and draft cancellation semantics.

The hosted ARM lane is portability evidence; it does not claim Raspberry Pi or HIL timing performance. Broad AMDGPU remains explicitly dispatched while #200 is unresolved.

Closes #202
