### PR TITLE
PE-00: characterize prepared execution ownership

### DIFF
--- a/benchmarks/benchmark_fixed_size_arrays.jl
+++ b/benchmarks/benchmark_fixed_size_arrays.jl
@@ -1,0 +1,294 @@
+using TOML
+using Pkg
+
+const FIXED_SIZE_ARRAYS_PROBE_MODE = ARGS == ["--probe"]
+FIXED_SIZE_ARRAYS_PROBE_MODE || (@eval using FixedSizeArrays)
+
+const REPOSITORY_ROOT = normpath(joinpath(@__DIR__, ".."))
+const CONTRACT_PATH =
+    joinpath(@__DIR__, "contracts", "fixed_size_arrays.toml")
+const ISOLATED_PROJECT = joinpath(@__DIR__, "fixed_size_arrays")
+
+function integer_summary(values::Vector{Int})
+    sorted = sort(values)
+    return Dict(
+        "minimum_ns" => first(sorted),
+        "median_ns" => sorted[cld(length(sorted), 2)],
+        "maximum_ns" => last(sorted),
+    )
+end
+
+function run_probe()
+    contract = TOML.parsefile(CONTRACT_PATH)
+    count = Int(contract["vector_length"])
+
+    GC.gc()
+    load_start = time_ns()
+    @eval using FixedSizeArrays
+    load_ns = Int(time_ns() - load_start)
+
+    GC.gc()
+    first_start = time_ns()
+    values = Base.invokelatest() do
+        result = FixedSizeArrays.FixedSizeVectorDefault{Float64}(
+            undef, count)
+        fill!(result, 1.0)
+        result
+    end
+    first_construction_ns = Int(time_ns() - first_start)
+
+    correctness = Base.invokelatest(values) do loaded_values
+        length(loaded_values) == count && sum(loaded_values) == count
+    end
+    TOML.print(stdout, Dict(
+        "load_ns" => load_ns,
+        "first_construction_ns" => first_construction_ns,
+        "correctness_passed" => correctness,
+    ); sorted=true)
+    return correctness ? 0 : 1
+end
+
+@noinline function indexed_sum(values)
+    result = zero(eltype(values))
+    @inbounds for index in eachindex(values)
+        result += values[index]
+    end
+    return result
+end
+
+@noinline function iterated_sum(values)
+    result = zero(eltype(values))
+    for value in values
+        result += value
+    end
+    return result
+end
+
+@noinline copy_values!(destination, source) = copyto!(destination, source)
+
+@inline project_armed_storage_eltype_allowed(::Type{T}) where {T} =
+    isconcretetype(T)
+
+function warmed_allocation(operation)
+    operation()
+    operation()
+    GC.gc()
+    return @allocated operation()
+end
+
+function construction_allocation(constructor)
+    constructor()
+    GC.gc()
+    return @allocated constructor()
+end
+
+function probe_command()
+    julia = Base.julia_cmd()
+    return `$julia --startup-file=no --history-file=no --threads=1 --project=$ISOLATED_PROJECT $(@__FILE__) --probe`
+end
+
+function run_fresh_probe()
+    command = setenv(probe_command(), "JULIA_NUM_THREADS" => "1")
+    return TOML.parse(read(command, String))
+end
+
+function resolved_dependencies()
+    dependencies = Pkg.dependencies()
+    DependencyValue = Union{Bool,String}
+    selected = Dict{String,DependencyValue}[]
+    for (uuid, dependency) in pairs(dependencies)
+        dependency.name in ("FixedSizeArrays", "Collects") || continue
+        push!(selected, Dict{String,DependencyValue}(
+            "direct" => dependency.is_direct_dep,
+            "name" => dependency.name,
+            "uuid" => string(uuid),
+            "version" => string(dependency.version),
+        ))
+    end
+    sort!(selected; by=entry -> entry["name"])
+    return selected
+end
+
+function git_output(arguments...)
+    return strip(read(`git -C $REPOSITORY_ROOT $(arguments)`, String))
+end
+
+function run_characterization(output_path::AbstractString)
+    contract = TOML.parsefile(CONTRACT_PATH)
+    count = Int(contract["vector_length"])
+    shape = Tuple(Int.(contract["matrix_shape"]))
+    observations = [run_fresh_probe() for _ in
+        1:Int(contract["fresh_process_runs"])]
+    all(observation["correctness_passed"] for observation in observations) ||
+        error("a FixedSizeArrays fresh-process probe failed")
+
+    fixed = FixedSizeVectorDefault{Float64}(undef, count)
+    source = FixedSizeVectorDefault{Float64}(undef, count)
+    fill!(fixed, 1.0)
+    fill!(source, 2.0)
+    indexed_sum(fixed)
+    iterated_sum(fixed)
+    copy_values!(fixed, source)
+
+    indexed_allocated = warmed_allocation(() -> indexed_sum(fixed))
+    iterated_allocated = warmed_allocation(() -> iterated_sum(fixed))
+    copy_allocated = warmed_allocation(() -> copy_values!(fixed, source))
+
+    short = FixedSizeVectorDefault{Float64}(undef, 8)
+    long = FixedSizeVectorDefault{Float64}(undef, 16)
+    matrix = FixedSizeMatrixDefault{Float64}(undef, shape)
+    alternate_matrix = FixedSizeMatrixDefault{Float64}(
+        undef, (first(shape) + 1, last(shape)))
+    any_values = FixedSizeVectorDefault{Any}(undef, 2)
+    any_values[1] = 1
+    any_values[2] = 2.0
+
+    resize_rejected = try
+        resize!(short, 4)
+        false
+    catch error
+        error isa MethodError
+    end
+    push_rejected = try
+        push!(short, 1.0)
+        false
+    catch error
+        error isa MethodError
+    end
+
+    memory_constructor = () -> begin
+        values = Memory{Float64}(undef, count)
+        fill!(values, 1.0)
+        values
+    end
+    vector_constructor = () -> fill(1.0, count)
+    fixed_constructor = () -> begin
+        values = FixedSizeVectorDefault{Float64}(undef, count)
+        fill!(values, 1.0)
+        values
+    end
+
+    memory_values = memory_constructor()
+    vector_values = vector_constructor()
+    artifact = Dict(
+        "schema_version" => 1,
+        "name" => contract["name"],
+        "source_contract" => relpath(CONTRACT_PATH, REPOSITORY_ROOT),
+        "repository_head" => git_output("rev-parse", "HEAD"),
+        "repository_dirty" => !isempty(git_output(
+            "status", "--porcelain", "--untracked-files=normal")),
+        "julia_version" => string(VERSION),
+        "fixed_size_arrays_version" => string(Base.pkgversion(
+            FixedSizeArrays)),
+        "resolved_dependencies" => resolved_dependencies(),
+        "fresh_process_runs" => length(observations),
+        "correctness_passed" => true,
+        "load_samples_ns" =>
+            Int[entry["load_ns"] for entry in observations],
+        "first_construction_samples_ns" =>
+            Int[entry["first_construction_ns"] for entry in observations],
+        "load_summary" => integer_summary(
+            Int[entry["load_ns"] for entry in observations]),
+        "first_construction_summary" => integer_summary(
+            Int[entry["first_construction_ns"] for entry in observations]),
+        "warmed_allocated_bytes" => Dict(
+            "indexing" => indexed_allocated,
+            "iteration" => iterated_allocated,
+            "copyto" => copy_allocated,
+        ),
+        "inference" => Dict(
+            "indexed_sum" => Core.Compiler.return_type(
+                indexed_sum, Tuple{typeof(fixed)}) === Float64,
+            "iterated_sum" => Core.Compiler.return_type(
+                iterated_sum, Tuple{typeof(fixed)}) === Float64,
+            "copyto" => Core.Compiler.return_type(
+                copy_values!, Tuple{typeof(fixed),typeof(source)}) ===
+                    typeof(fixed),
+        ),
+        "shape_contract" => Dict(
+            "runtime_vector_lengths_share_type" =>
+                typeof(short) === typeof(long),
+            "runtime_matrix_shapes_share_type" =>
+                typeof(matrix) === typeof(alternate_matrix),
+            "matrix_dimensions" => collect(size(matrix)),
+            "alternate_matrix_dimensions" =>
+                collect(size(alternate_matrix)),
+            "matrix_rank_in_type" => ndims(typeof(matrix)),
+            "resize_rejected" => resize_rejected,
+            "push_rejected" => push_rejected,
+        ),
+        "element_type_contract" => Dict(
+            "any_is_constructible" => eltype(any_values) === Any,
+            "concrete_is_accepted" =>
+                project_armed_storage_eltype_allowed(eltype(fixed)),
+            "any_is_rejected" =>
+                !project_armed_storage_eltype_allowed(eltype(any_values)),
+        ),
+        "storage_comparison" => Dict(
+            "fixed_size_array" => Dict(
+                "construction_allocated_bytes" =>
+                    construction_allocation(fixed_constructor),
+                "summarysize_bytes" => Base.summarysize(fixed),
+            ),
+            "memory" => Dict(
+                "construction_allocated_bytes" =>
+                    construction_allocation(memory_constructor),
+                "summarysize_bytes" => Base.summarysize(memory_values),
+            ),
+            "vector" => Dict(
+                "construction_allocated_bytes" =>
+                    construction_allocation(vector_constructor),
+                "summarysize_bytes" => Base.summarysize(vector_values),
+            ),
+            "dependency_backing_inspected" => false,
+        ),
+        "results" => observations,
+    )
+
+    artifact["correctness_passed"] =
+        all(iszero, values(artifact["warmed_allocated_bytes"])) &&
+        all(identity, values(artifact["inference"])) &&
+        artifact["shape_contract"]["runtime_vector_lengths_share_type"] &&
+        artifact["shape_contract"]["runtime_matrix_shapes_share_type"] &&
+        artifact["shape_contract"]["resize_rejected"] &&
+        artifact["shape_contract"]["push_rejected"] &&
+        artifact["element_type_contract"]["any_is_constructible"] &&
+        artifact["element_type_contract"]["concrete_is_accepted"] &&
+        artifact["element_type_contract"]["any_is_rejected"] &&
+        !artifact["storage_comparison"]["dependency_backing_inspected"]
+    artifact["correctness_passed"] ||
+        error("FixedSizeArrays characterization contract failed")
+
+    mkpath(dirname(output_path))
+    open(output_path, "w") do io
+        TOML.print(io, artifact; sorted=true)
+    end
+    TOML.print(stdout, Dict(
+        "output_path" => relpath(output_path, REPOSITORY_ROOT),
+        "load_median_ns" => artifact["load_summary"]["median_ns"],
+        "first_construction_median_ns" =>
+            artifact["first_construction_summary"]["median_ns"],
+        "correctness_passed" => artifact["correctness_passed"],
+    ); sorted=true)
+    return nothing
+end
+
+function parse_output_path(arguments)
+    index = findfirst(==("--output"), arguments)
+    index === nothing && return nothing
+    index < length(arguments) ||
+        throw(ArgumentError("--output requires a path"))
+    return abspath(arguments[index + 1])
+end
+
+function main(arguments=ARGS)
+    arguments == ["--probe"] && exit(run_probe())
+    contract = TOML.parsefile(CONTRACT_PATH)
+    output = parse_output_path(arguments)
+    output === nothing && (output = joinpath(
+        REPOSITORY_ROOT, String(contract["artifact_path"])))
+    run_characterization(output)
+    return nothing
+end
+
+main()

--- a/benchmarks/benchmark_fixed_size_arrays.jl
+++ b/benchmarks/benchmark_fixed_size_arrays.jl
@@ -117,6 +117,9 @@ function run_characterization(output_path::AbstractString)
     contract = TOML.parsefile(CONTRACT_PATH)
     count = Int(contract["vector_length"])
     shape = Tuple(Int.(contract["matrix_shape"]))
+    cpu_information = Sys.cpu_info()
+    cpu_model = isempty(cpu_information) ?
+        "unknown" : first(cpu_information).model
     observations = [run_fresh_probe() for _ in
         1:Int(contract["fresh_process_runs"])]
     all(observation["correctness_passed"] for observation in observations) ||
@@ -177,7 +180,15 @@ function run_characterization(output_path::AbstractString)
         "repository_head" => git_output("rev-parse", "HEAD"),
         "repository_dirty" => !isempty(git_output(
             "status", "--porcelain", "--untracked-files=normal")),
+        "kernel" => string(Sys.KERNEL),
+        "architecture" => string(Sys.ARCH),
+        "cpu_target" => string(Sys.CPU_NAME),
+        "cpu_model" => cpu_model,
+        "logical_cpu_threads" => Sys.CPU_THREADS,
         "julia_version" => string(VERSION),
+        "julia_threads" => Threads.nthreads(),
+        "julia_cpu_target_env" =>
+            get(ENV, "JULIA_CPU_TARGET", "default"),
         "fixed_size_arrays_version" => string(Base.pkgversion(
             FixedSizeArrays)),
         "resolved_dependencies" => resolved_dependencies(),

--- a/benchmarks/contracts/fixed_size_arrays.toml
+++ b/benchmarks/contracts/fixed_size_arrays.toml
@@ -1,0 +1,29 @@
+schema_version = 1
+name = "fixed_size_arrays_prepared_storage"
+evidence_class = "isolated dependency and host-storage characterization"
+fixed_size_arrays_compat = "1.3"
+characterized_version = "1.3.0"
+julia_version = "1.12.6"
+fresh_process_runs = 5
+vector_length = 4096
+matrix_shape = [64, 64]
+artifact_path = "benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml"
+
+scope_exclusions = [
+    "AdaptiveOpticsSim runtime integration; the root package does not yet depend on FixedSizeArrays",
+    "accelerator numerical storage, device residency, and kernel launch behavior",
+    "absolute latency thresholds across hosts or cache states",
+    "dependency-internal backing representation, which AdaptiveOpticsSim must not inspect or expose",
+]
+
+[contract]
+process = "one Julia 1.12.6 process per package-load/first-construction observation with --startup-file=no, --history-file=no, and one Julia thread"
+cache_state = "ordinary warm package and filesystem caches; dependency resolution and precompilation are completed before observations"
+package_load_boundary = "time @eval using FixedSizeArrays after the TOML harness has loaded"
+first_construction_boundary = "construct and initialize one FixedSizeVectorDefault{Float64} at the configured runtime length"
+warmed_operations = ["scalar indexing", "iteration", "copyto!"]
+allocation_oracle = "each warmed operation reports zero Julia heap bytes"
+shape_oracle = "different runtime lengths and shapes retain the same concrete FixedSizeArray type, while resize! and push! are unavailable"
+element_type_oracle = "FixedSizeArray itself permits Any; the project armed-storage predicate accepts a concrete element type and deliberately rejects Any"
+storage_oracle = "record construction allocation and Base.summarysize for FixedSizeArray, Memory, and Vector without observing FixedSizeArray backing fields"
+interpretation = "dependency proof only; it does not promote a package runtime dependency or a CPU/GPU performance claim"

--- a/benchmarks/fixed_size_arrays/.gitignore
+++ b/benchmarks/fixed_size_arrays/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/benchmarks/fixed_size_arrays/Project.toml
+++ b/benchmarks/fixed_size_arrays/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+FixedSizeArrays = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
+
+[compat]
+FixedSizeArrays = "1.3"
+julia = "1.12"

--- a/benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml
+++ b/benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml
@@ -1,12 +1,12 @@
 correctness_passed = true
-first_construction_samples_ns = [14678052, 14952075, 14403859, 14887605, 15099041]
+first_construction_samples_ns = [14895124, 15944800, 14991676, 15388518, 16104880]
 fixed_size_arrays_version = "1.3.0"
 fresh_process_runs = 5
 julia_version = "1.12.6"
-load_samples_ns = [10379804, 10644530, 10635663, 10476155, 10496372]
+load_samples_ns = [10459170, 11106953, 10569487, 10676558, 10491381]
 name = "fixed_size_arrays_prepared_storage"
-repository_dirty = true
-repository_head = "9ebb326ceaed33c99eecf88ec1242b737177980f"
+repository_dirty = false
+repository_head = "1a79499486532a4a052d8370eabb30c4ac4c78eb"
 schema_version = 1
 source_contract = "benchmarks/contracts/fixed_size_arrays.toml"
 
@@ -16,9 +16,9 @@ any_is_rejected = true
 concrete_is_accepted = true
 
 [first_construction_summary]
-maximum_ns = 15099041
-median_ns = 14887605
-minimum_ns = 14403859
+maximum_ns = 16104880
+median_ns = 15388518
+minimum_ns = 14895124
 
 [inference]
 copyto = true
@@ -26,9 +26,9 @@ indexed_sum = true
 iterated_sum = true
 
 [load_summary]
-maximum_ns = 10644530
-median_ns = 10496372
-minimum_ns = 10379804
+maximum_ns = 11106953
+median_ns = 10569487
+minimum_ns = 10459170
 
 [[resolved_dependencies]]
 direct = false
@@ -43,24 +43,24 @@ version = "1.3.0"
 
 [[results]]
 correctness_passed = true
-first_construction_ns = 14678052
-load_ns = 10379804
+first_construction_ns = 14895124
+load_ns = 10459170
 [[results]]
 correctness_passed = true
-first_construction_ns = 14952075
-load_ns = 10644530
+first_construction_ns = 15944800
+load_ns = 11106953
 [[results]]
 correctness_passed = true
-first_construction_ns = 14403859
-load_ns = 10635663
+first_construction_ns = 14991676
+load_ns = 10569487
 [[results]]
 correctness_passed = true
-first_construction_ns = 14887605
-load_ns = 10476155
+first_construction_ns = 15388518
+load_ns = 10676558
 [[results]]
 correctness_passed = true
-first_construction_ns = 15099041
-load_ns = 10496372
+first_construction_ns = 16104880
+load_ns = 10491381
 
 [shape_contract]
 alternate_matrix_dimensions = [65, 64]

--- a/benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml
+++ b/benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml
@@ -1,12 +1,19 @@
+architecture = "x86_64"
 correctness_passed = true
-first_construction_samples_ns = [14895124, 15944800, 14991676, 15388518, 16104880]
+cpu_model = "AMD Ryzen 7 6800H with Radeon Graphics"
+cpu_target = "znver3"
+first_construction_samples_ns = [14850007, 14889632, 15502940, 14824760, 15054290]
 fixed_size_arrays_version = "1.3.0"
 fresh_process_runs = 5
+julia_cpu_target_env = "default"
+julia_threads = 1
 julia_version = "1.12.6"
-load_samples_ns = [10459170, 11106953, 10569487, 10676558, 10491381]
+kernel = "Linux"
+load_samples_ns = [10468967, 10333344, 10400499, 10530322, 10573342]
+logical_cpu_threads = 16
 name = "fixed_size_arrays_prepared_storage"
 repository_dirty = false
-repository_head = "1a79499486532a4a052d8370eabb30c4ac4c78eb"
+repository_head = "22b4b73f3a45e3c4a22e2283cd2ae19da1432f2c"
 schema_version = 1
 source_contract = "benchmarks/contracts/fixed_size_arrays.toml"
 
@@ -16,9 +23,9 @@ any_is_rejected = true
 concrete_is_accepted = true
 
 [first_construction_summary]
-maximum_ns = 16104880
-median_ns = 15388518
-minimum_ns = 14895124
+maximum_ns = 15502940
+median_ns = 14889632
+minimum_ns = 14824760
 
 [inference]
 copyto = true
@@ -26,9 +33,9 @@ indexed_sum = true
 iterated_sum = true
 
 [load_summary]
-maximum_ns = 11106953
-median_ns = 10569487
-minimum_ns = 10459170
+maximum_ns = 10573342
+median_ns = 10468967
+minimum_ns = 10333344
 
 [[resolved_dependencies]]
 direct = false
@@ -43,24 +50,24 @@ version = "1.3.0"
 
 [[results]]
 correctness_passed = true
-first_construction_ns = 14895124
-load_ns = 10459170
+first_construction_ns = 14850007
+load_ns = 10468967
 [[results]]
 correctness_passed = true
-first_construction_ns = 15944800
-load_ns = 11106953
+first_construction_ns = 14889632
+load_ns = 10333344
 [[results]]
 correctness_passed = true
-first_construction_ns = 14991676
-load_ns = 10569487
+first_construction_ns = 15502940
+load_ns = 10400499
 [[results]]
 correctness_passed = true
-first_construction_ns = 15388518
-load_ns = 10676558
+first_construction_ns = 14824760
+load_ns = 10530322
 [[results]]
 correctness_passed = true
-first_construction_ns = 16104880
-load_ns = 10491381
+first_construction_ns = 15054290
+load_ns = 10573342
 
 [shape_contract]
 alternate_matrix_dimensions = [65, 64]

--- a/benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml
+++ b/benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml
@@ -1,0 +1,92 @@
+correctness_passed = true
+first_construction_samples_ns = [14678052, 14952075, 14403859, 14887605, 15099041]
+fixed_size_arrays_version = "1.3.0"
+fresh_process_runs = 5
+julia_version = "1.12.6"
+load_samples_ns = [10379804, 10644530, 10635663, 10476155, 10496372]
+name = "fixed_size_arrays_prepared_storage"
+repository_dirty = true
+repository_head = "9ebb326ceaed33c99eecf88ec1242b737177980f"
+schema_version = 1
+source_contract = "benchmarks/contracts/fixed_size_arrays.toml"
+
+[element_type_contract]
+any_is_constructible = true
+any_is_rejected = true
+concrete_is_accepted = true
+
+[first_construction_summary]
+maximum_ns = 15099041
+median_ns = 14887605
+minimum_ns = 14403859
+
+[inference]
+copyto = true
+indexed_sum = true
+iterated_sum = true
+
+[load_summary]
+maximum_ns = 10644530
+median_ns = 10496372
+minimum_ns = 10379804
+
+[[resolved_dependencies]]
+direct = false
+name = "Collects"
+uuid = "08986516-18db-4a8b-8eaa-f5ef1828d8f1"
+version = "1.1.0"
+[[resolved_dependencies]]
+direct = true
+name = "FixedSizeArrays"
+uuid = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
+version = "1.3.0"
+
+[[results]]
+correctness_passed = true
+first_construction_ns = 14678052
+load_ns = 10379804
+[[results]]
+correctness_passed = true
+first_construction_ns = 14952075
+load_ns = 10644530
+[[results]]
+correctness_passed = true
+first_construction_ns = 14403859
+load_ns = 10635663
+[[results]]
+correctness_passed = true
+first_construction_ns = 14887605
+load_ns = 10476155
+[[results]]
+correctness_passed = true
+first_construction_ns = 15099041
+load_ns = 10496372
+
+[shape_contract]
+alternate_matrix_dimensions = [65, 64]
+matrix_dimensions = [64, 64]
+matrix_rank_in_type = 2
+push_rejected = true
+resize_rejected = true
+runtime_matrix_shapes_share_type = true
+runtime_vector_lengths_share_type = true
+
+[storage_comparison]
+dependency_backing_inspected = false
+
+    [storage_comparison.fixed_size_array]
+    construction_allocated_bytes = 32808
+    summarysize_bytes = 32800
+
+    [storage_comparison.memory]
+    construction_allocated_bytes = 32808
+    summarysize_bytes = 32784
+
+    [storage_comparison.vector]
+    construction_allocated_bytes = 32840
+    summarysize_bytes = 32808
+
+[warmed_allocated_bytes]
+copyto = 0
+indexing = 0
+iteration = 0

--- a/test/contracts/prepared_execution_hil_impact.toml
+++ b/test/contracts/prepared_execution_hil_impact.toml
@@ -1,0 +1,105 @@
+schema_version = 1
+name = "prepared_execution_adaptive_optics_hil_impact"
+status = "frozen_source_snapshot"
+repository = "https://github.com/DarrylGamroth/AdaptiveOpticsHIL.jl.git"
+source_revision = "4ab3c1dc9dae81c34aa4aa6422216e1dab71fcc5"
+adaptive_optics_sim_pin = "f12ae7beceaf460fb6953d4bb07874be5197d4ff"
+scope = ["src", "test", "benchmarks"]
+claim = "PE-00 records downstream references and construction assumptions; it does not change AdaptiveOpticsHIL or claim compatibility with future ownership migrations"
+
+[project_files]
+package = "Project.toml"
+package_sha256 = "ebf9d9865bce883f8c217b54930ebeed778fb620d66356bd281e62528ae18e0d"
+benchmarks = "benchmarks/Project.toml"
+benchmarks_sha256 = "eb602af43e863683ee604d0690f3f266906946531b177ba040bf83ebe3c872c4"
+
+[ownership]
+affected_symbols = [
+    "PreparedPlantEventLoop",
+    "PlantEventLoopState",
+    "PlantEventLoopWorkspace",
+    "PreparedPathExecutor",
+    "PreparedCommandEndpoint",
+    "CommandEndpointState",
+    "CommandDispositionWorkspace",
+    "AcquisitionProductContract",
+    "AcquisitionProducts",
+]
+construction_assumptions = [
+    "A plant-backed PreparedCommandBridge retains one exact PreparedPlantEventLoop and constructs PlantEventLoopState and PlantEventLoopWorkspace from that same owner",
+    "PreparedExecutionOwnerExecutor specializes on and retains the exact PreparedPlantEventLoop, PlantEventLoopState, and PlantEventLoopWorkspace types and identities for one run",
+    "HIL command ports retain PreparedCommandEndpoint, CommandEndpointState, and CommandDispositionWorkspace ownership boundaries",
+    "HIL acquisition publishers validate AcquisitionProductContract before copying complete AcquisitionProducts into transport-neutral lease storage",
+    "HIL test and benchmark fixtures extend preparation seams and directly construct PreparedPathExecutor values; PE-08 must update these callers without compatibility adapters",
+]
+
+[direct_memory]
+policy = "downstream debt; migrate AdaptiveOpticsHIL armed storage without exposing or inspecting FixedSizeArrays backing"
+source_total = 87
+test_total = 9
+benchmarks_total = 0
+migration_gate = "PE-08"
+files = [
+    ["src/execution.jl", 49],
+    ["src/lifecycle/failure_coordination.jl", 10],
+    ["src/ownership.jl", 6],
+    ["src/ports/command.jl", 6],
+    ["src/serial.jl", 14],
+    ["src/timing/external_timestamps.jl", 2],
+    ["test/execution.jl", 3],
+    ["test/lifecycle.jl", 6],
+]
+
+[[reference_files]]
+scope = "src"
+path = "src/execution.jl"
+sha256 = "465328f18b4c1132a40c95901b3dd87f53771ca5bbc664cd4ea4830b4dba3ebc"
+symbols = ["PreparedPlantEventLoop", "PlantEventLoopState", "PlantEventLoopWorkspace"]
+
+[[reference_files]]
+scope = "src"
+path = "src/ports/acquisition.jl"
+sha256 = "7190b832c5263c3005306b466ba8c2b3102f25f620eee22789bfdea8f9af26a6"
+symbols = ["AcquisitionProductContract", "AcquisitionProducts"]
+
+[[reference_files]]
+scope = "src"
+path = "src/ports/command.jl"
+sha256 = "e15ccd7e68c92dc70352e4e974628bf51fae5fba719f64cdafed379e66415df5"
+symbols = ["PreparedPlantEventLoop", "PlantEventLoopState", "PlantEventLoopWorkspace", "PreparedCommandEndpoint", "CommandEndpointState", "CommandDispositionWorkspace"]
+
+[[reference_files]]
+scope = "src"
+path = "src/ports.jl"
+sha256 = "b50771303366d60f1296f08dfd32b9d3a63bf2575ec2a545008406b915332aec"
+symbols = ["PreparedPlantEventLoop", "PlantEventLoopState", "PlantEventLoopWorkspace", "PreparedCommandEndpoint", "CommandEndpointState", "CommandDispositionWorkspace", "AcquisitionProductContract", "AcquisitionProducts"]
+
+[[reference_files]]
+scope = "src"
+path = "src/serial.jl"
+sha256 = "4bcd67d1e41d932f1c93afaa6b38fbfcee4a44f982e64aa022a629811653bb35"
+symbols = ["PreparedPlantEventLoop", "AcquisitionProducts"]
+
+[[reference_files]]
+scope = "test"
+path = "test/execution.jl"
+sha256 = "10a754bbfdfd9f23c8ea476bb13b419f290224fc0dc256a24c3dbc4ad64e7755"
+symbols = ["PlantEventLoopState", "PlantEventLoopWorkspace", "PreparedPathExecutor", "AcquisitionProducts"]
+
+[[reference_files]]
+scope = "test"
+path = "test/ports.jl"
+sha256 = "eef85cb300348c588808d8c755fad521e091bdd39bea6150173eb38ecc16b853"
+symbols = ["AcquisitionProductContract", "AcquisitionProducts"]
+
+[[reference_files]]
+scope = "test"
+path = "test/serial.jl"
+sha256 = "329c45223e7780b124607ba26a6c3a790b9ee8f357be9829d06482d7e0871960"
+symbols = ["PreparedPlantEventLoop", "PlantEventLoopState", "PlantEventLoopWorkspace", "PreparedPathExecutor", "AcquisitionProducts"]
+
+[[reference_files]]
+scope = "benchmarks"
+path = "benchmarks/support/gate4a_serial_workload.jl"
+sha256 = "8896c4e0a8e2264861cef20dfa84f30d3e2faaf0cee59d8c330825b193166310"
+symbols = ["PreparedPathExecutor"]

--- a/test/contracts/prepared_execution_ownership.toml
+++ b/test/contracts/prepared_execution_ownership.toml
@@ -1,0 +1,1537 @@
+schema_version = 1
+name = "prepared_execution_ownership"
+status = "characterized_baseline"
+tracker_issue = 225
+work_issue = 227
+source_revision = "9ebb326ceaed33c99eecf88ec1242b737177980f"
+policy_revision = "9ebb326ceaed33c99eecf88ec1242b737177980f"
+scope = ["src","ext"]
+claim = "PE-00 records and ratchets current ownership and type-erasure debt; it does not migrate runtime representation or promote hardware support"
+
+[type_inventory]
+vocabulary_tokens = ["definition","definitions","parameters","params","plan","prepared","product","products","state","strategy","workspace"]
+columns = ["name","declaration","field_count","current_role","target_roles","mutable","persistent_state","product_visibility","exact_binding","backend_relevance","cpu_hot_path","migration_gate"]
+target_roles_semantics = "Canonical destinations for responsibilities carried by the current value; multiple roles identify legacy mixed ownership that must be decomposed"
+allowed_current_roles = ["definition","params","plan","prepared","state","workspace","product","strategy"]
+allowed_target_roles = ["definition","plan","plan_interface","state","workspace","product","prepared_owner","prepared_owner_interface","strategy","binding_token","support"]
+allowed_product_visibility = ["internal","caller_visible"]
+allowed_backend_relevance = ["backend_neutral","backend_parameterized","backend_specific"]
+allowed_migration_gates = ["PE-00","PE-01","PE-02","PE-03","PE-04","PE-05","PE-06","PE-07"]
+baseline_type_count = 381
+baseline_mixed_type_count = 32
+
+[[type_inventory.files]]
+path = "ext/AdaptiveOpticsSimAMDGPUExt.jl"
+owner = "Backends"
+entries = [
+    ["AMDGPUPreparedDeviceExecutionContext","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_specific",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "ext/AdaptiveOpticsSimAcceleratedKernelsExt.jl"
+owner = "Ensembles"
+entries = [
+    ["AcceleratedKernelsSchedulerState","struct",1,"state",["state"],false,true,"internal",false,"backend_neutral",true,"PE-07"],
+]
+
+[[type_inventory.files]]
+path = "ext/AdaptiveOpticsSimAppleAccelerateExt.jl"
+owner = "Backends"
+entries = [
+    ["AdaptiveOpticsAppleFFTPlan","struct",5,"plan",["plan"],false,false,"internal",false,"backend_specific",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "ext/AdaptiveOpticsSimCUDAExt.jl"
+owner = "Backends"
+entries = [
+    ["CUDAPreparedDeviceExecutionContext","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_specific",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "ext/AdaptiveOpticsSimDaggerExt.jl"
+owner = "Ensembles"
+entries = [
+    ["DaggerSchedulerState","struct",0,"state",["state"],false,false,"internal",false,"backend_neutral",false,"PE-07"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/atmospheres.jl"
+owner = "Atmospheres"
+entries = [
+    ["AbstractTimedAtmosphereDefinition","abstract_type",-1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/atmospheric_field_propagation.jl"
+owner = "Atmospheres"
+entries = [
+    ["AbstractAtmosphericFieldExecutionPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["AtmosphericFieldPropagationParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["AtmosphericFieldPropagationState","struct",2,"state",["plan","workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["GeometricFieldAsyncPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["GeometricFieldSynchronousPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["LayeredFresnelFieldAsyncPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["LayeredFresnelFieldSynchronousPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/definitions.jl"
+owner = "Atmospheres"
+entries = [
+    ["AtmosphereLayerDefinition","struct",5,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["InfiniteMultiLayerAtmosphereDefinition","struct",5,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["KolmogorovAtmosphereDefinition","struct",2,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["MultiLayerAtmosphereDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["_FixedAtmosphereLayerDefinitions","struct",1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/direction_batch.jl"
+owner = "Atmospheres"
+entries = [
+    ["AtmosphereDirectionBatchParams","struct",10,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["AtmosphereDirectionBatchWorkspace","mutable_struct",5,"workspace",["workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["PreparedAtmosphereDirectionBatch","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/infinite_screen.jl"
+owner = "Atmospheres"
+entries = [
+    ["InfiniteLayerParams","struct",4,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["InfiniteLayerState","mutable_struct",4,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["InfiniteMultiLayerParams","struct",9,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["InfiniteMultiLayerState","mutable_struct",1,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["InfinitePhaseScreenParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["InfinitePhaseScreenState","mutable_struct",15,"state",["plan","state","workspace"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/kolmogorov.jl"
+owner = "Atmospheres"
+entries = [
+    ["KolmogorovParams","struct",3,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["KolmogorovState","mutable_struct",13,"state",["plan","state","workspace"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/multilayer.jl"
+owner = "Atmospheres"
+entries = [
+    ["MovingLayerParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["MovingLayerState","mutable_struct",3,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["MultiLayerParams","struct",9,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["MultiLayerState","mutable_struct",1,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/phase_stats.jl"
+owner = "Atmospheres"
+entries = [
+    ["PhaseStatsWorkspace","struct",7,"workspace",["workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/atmosphere/source_geometry.jl"
+owner = "Atmospheres"
+entries = [
+    ["AtmosphereTimelineState","mutable_struct",3,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["PreparedAtmosphereDirections","struct",2,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/backends/arrays.jl"
+owner = "Backends"
+entries = [
+    ["_AbstractPreparedDeviceExecutionContext","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_specific",false,"PE-01"],
+    ["_HostPreparedDeviceExecutionContext","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_specific",true,"PE-03"],
+    ["_PreparedArrayTransferCompletionStatus","enum",-1,"prepared",["support"],false,false,"internal",false,"backend_specific",true,"PE-03"],
+    ["_PreparedArrayTransferSubmissionStatus","enum",-1,"prepared",["support"],false,false,"internal",false,"backend_specific",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/backends/reductions.jl"
+owner = "Backends"
+entries = [
+    ["AbstractReductionExecutionPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_specific",false,"PE-01"],
+    ["DirectReductionPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_specific",true,"PE-02"],
+    ["HostMirrorReductionPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_specific",true,"PE-02"],
+]
+
+[[type_inventory.files]]
+path = "src/calibration/gain_sensing_camera.jl"
+owner = "Calibration"
+entries = [
+    ["GSCFFTWorkspace","struct",5,"workspace",["workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-07"],
+]
+
+[[type_inventory.files]]
+path = "src/calibration/interaction_matrix.jl"
+owner = "Calibration"
+entries = [
+    ["AbstractCalibrationCommandPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+]
+
+[[type_inventory.files]]
+path = "src/core/workspace.jl"
+owner = "Root"
+entries = [
+    ["Workspace","mutable_struct",5,"workspace",["workspace"],true,false,"internal",false,"backend_neutral",true,"PE-07"],
+]
+
+[[type_inventory.files]]
+path = "src/detectors/detector_acquisition.jl"
+owner = "Detectors"
+entries = [
+    ["DetectorAcquisitionPlan","struct",8,"plan",["plan","prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-04"],
+    ["_DetectorAcquisitionPlanToken","struct",0,"plan",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-04"],
+]
+
+[[type_inventory.files]]
+path = "src/detectors/interface.jl"
+owner = "Detectors"
+entries = [
+    ["AbstractDetectorThermalState","abstract_type",-1,"state",["state"],false,true,"internal",false,"backend_parameterized",true,"PE-04"],
+    ["DetectorParams","struct",19,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["DetectorState","mutable_struct",17,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-04"],
+    ["DetectorThermalState","mutable_struct",1,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-04"],
+    ["FrameReadoutProducts","abstract_type",-1,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-04"],
+    ["HgCdTeReadoutProducts","type_alias",-1,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",true,"PE-04"],
+    ["MultiReadFrameReadoutProducts","mutable_struct",9,"product",["product"],true,false,"caller_visible",false,"backend_parameterized",false,"PE-04"],
+    ["NoFrameReadoutProducts","struct",0,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-04"],
+    ["NoThermalState","struct",0,"state",["state"],false,false,"internal",false,"backend_parameterized",false,"PE-04"],
+    ["SampledFrameReadoutProducts","struct",3,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-04"],
+    ["SkipperReadoutProducts","struct",2,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-04"],
+    ["UpTheRampReadoutProducts","mutable_struct",10,"product",["product"],true,false,"caller_visible",false,"backend_parameterized",false,"PE-04"],
+]
+
+[[type_inventory.files]]
+path = "src/detectors/linear_apd.jl"
+owner = "Detectors"
+entries = [
+    ["LinearAPDDetectorParams","struct",7,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["LinearAPDDetectorState","mutable_struct",2,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-04"],
+]
+
+[[type_inventory.files]]
+path = "src/detectors/mkid_array.jl"
+owner = "Detectors"
+entries = [
+    ["MKIDArrayDetectorParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["MKIDArrayDetectorState","mutable_struct",6,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-04"],
+]
+
+[[type_inventory.files]]
+path = "src/detectors/pipeline.jl"
+owner = "Detectors"
+entries = [
+    ["AbstractDetectorExecutionPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["DetectorDirectPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["DetectorHostMirrorPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+]
+
+[[type_inventory.files]]
+path = "src/detectors/spad_array.jl"
+owner = "Detectors"
+entries = [
+    ["SPADArrayDetectorParams","struct",6,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["SPADArrayDetectorState","mutable_struct",6,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-04"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/controllable_optics.jl"
+owner = "Optics"
+entries = [
+    ["ModalControllableOpticParams","struct",2,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["ModalControllableOpticState","struct",4,"state",["plan","state","workspace","product"],false,true,"caller_visible",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/deformable_mirror.jl"
+owner = "Optics"
+entries = [
+    ["DeformableMirrorParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["DeformableMirrorState","mutable_struct",9,"state",["plan","state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/direct_imaging.jl"
+owner = "Optics"
+entries = [
+    ["AbstractDirectImagingInputPlan","abstract_type",-1,"plan",["prepared_owner_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["DirectImagingPlan","struct",8,"plan",["plan","workspace","product","prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["DirectImagingWorkspace","struct",2,"workspace",["workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["PreparedBundledDirectImaging","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["PreparedDirectImaging","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["PreparedFieldImagingInput","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["PreparedIncoherentDirectImaging","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["PreparedPupilImagingInput","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/direct_imaging_batch.jl"
+owner = "Optics"
+entries = [
+    ["DirectImagingBatchProductContract","struct",8,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["DirectImagingBatchSampleParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["DirectImagingBatchWorkspace","mutable_struct",5,"workspace",["workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["DirectImagingBatchWorkspaceBindings","struct",7,"workspace",["prepared_owner"],false,false,"internal",true,"backend_neutral",false,"PE-03"],
+    ["PreparedDirectImagingBatch","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/electric_field.jl"
+owner = "Optics"
+entries = [
+    ["PupilFieldFormationPlan","struct",7,"plan",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/focal_plane_modulation.jl"
+owner = "Optics"
+entries = [
+    ["PreparedFocalPlaneModulation","struct",3,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/microlens_array.jl"
+owner = "Optics"
+entries = [
+    ["MicrolensArrayParams","struct",6,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["PreparedMicrolensPropagation","mutable_struct",30,"prepared",["plan","workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/planes.jl"
+owner = "Optics"
+entries = [
+    ["AbstractOpticalProduct","abstract_type",-1,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-03"],
+    ["NonCombinableProduct","struct",0,"product",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["OpticalProductBundle","struct",1,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-03"],
+    ["PreparedIncoherentInputs","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["PreparedIncoherentSum","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
+    ["_FixedOpticalProductVector","struct",1,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-03"],
+    ["_OpticalProductBundleToken","struct",0,"product",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-03"],
+    ["_PreparedIncoherentSumToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/propagation.jl"
+owner = "Optics"
+entries = [
+    ["FraunhoferPropagationParams","struct",4,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["FraunhoferPropagationState","struct",2,"state",["plan","workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["FresnelPropagationParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["FresnelPropagationState","struct",6,"state",["plan","workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/source.jl"
+owner = "Optics"
+entries = [
+    ["LGSSourceParams","struct",10,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["SourceParams","struct",6,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/spatial_filter.jl"
+owner = "Optics"
+entries = [
+    ["SpatialFilterParams","struct",4,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["SpatialFilterPlan","struct",6,"plan",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+    ["SpatialFilterWorkspace","struct",4,"workspace",["workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
+]
+
+[[type_inventory.files]]
+path = "src/optics/telescope.jl"
+owner = "Optics"
+entries = [
+    ["AbstractTelescopeDefinition","abstract_type",-1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TelescopeDefinition","struct",6,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TelescopeParams","struct",4,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/acquisition_lifecycles.jl"
+owner = "Plant"
+entries = [
+    ["AbstractAcquisitionLifecycleDefinition","abstract_type",-1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["AbstractAcquisitionLifecycleState","abstract_type",-1,"state",["state"],false,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["AbstractPreparedAcquisitionLifecycle","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/autonomous_periodic_optics.jl"
+owner = "Plant"
+entries = [
+    ["AutonomousPeriodicOpticDefinition","struct",4,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["CircularPyramidModulatorState","mutable_struct",10,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["CircularPyramidModulatorWorkspace","mutable_struct",4,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedCircularPyramidModulator","struct",4,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["PreparedCycleAveragedPyramidModulation","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedAutonomousPeriodicOptic","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/command_admission.jl"
+owner = "Plant"
+entries = [
+    ["CommandDispositionWorkspace","mutable_struct",3,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["CommandEndpointState","mutable_struct",17,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedCommandEndpoint","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_CommandEndpointStateBinding","mutable_struct",0,"state",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_CommandTransactionAdmissionPlan","struct",5,"plan",["support"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/command_application.jl"
+owner = "Plant"
+entries = [
+    ["CommandApplicationState","mutable_struct",7,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/command_authority.jl"
+owner = "Plant"
+entries = [
+    ["CommandAuthorityState","mutable_struct",7,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["CommandAuthorityWorkspace","struct",2,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedCommandAuthority","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedCommandAuthorityBinding","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedCommandAuthorityToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/command_fanout.jl"
+owner = "Plant"
+entries = [
+    ["_CommandFanoutLaneState","struct",3,"state",["state"],false,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_CommandFanoutLaneWorkspace","mutable_struct",12,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_CommandFanoutState","mutable_struct",4,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_CommandFanoutWorkspace","struct",3,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedCommandFanout","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedCommandFanoutBinding","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedCommandFanoutLane","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/command_publications.jl"
+owner = "Plant"
+entries = [
+    ["PreparedTargetLocalCommandEndpoint","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedTargetLocalControllableOptic","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["TargetLocalCommandEndpointState","mutable_struct",8,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["TargetLocalControllableOpticState","mutable_struct",5,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["TargetLocalControllableOpticWorkspace","struct",2,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/controllable_optics.jl"
+owner = "Plant"
+entries = [
+    ["PreparedControllableOptic","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedControllableOpticPathBindings","struct",6,"prepared",["plan","prepared_owner"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["PreparedControllableOpticPlaneGroup","struct",4,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedControllableOpticPathBindingsToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedControllableOpticToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedPlantCommandEndpoint","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/controller_routing.jl"
+owner = "Plant"
+entries = [
+    ["PreparedControllerOutputRoute","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedControllerOutputRouting","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedControllerOutputRouteToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedControllerOutputRoutingToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/definitions.jl"
+owner = "Plant"
+entries = [
+    ["AcquisitionDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["ColdPlantModelDefinition","struct",0,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["ControllableOpticDefinition","struct",5,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["OpticalPathDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["PlantDefinition","struct",7,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["SampledAberrationDefinition","struct",7,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["_PlantDefinitionIdentity","mutable_struct",0,"definition",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_UnsupportedPlantModelDefinition","struct",0,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/deformable_mirror.jl"
+owner = "Plant"
+entries = [
+    ["_PlantDeformableMirrorState","mutable_struct",1,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PlantDeformableMirrorWorkspace","mutable_struct",1,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedPlantDeformableMirror","struct",7,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/detector_acquisition_events.jl"
+owner = "Plant"
+entries = [
+    ["AbstractDetectorAcquisitionLifecycleDefinition","abstract_type",-1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["AbstractDetectorAcquisitionLifecycleState","abstract_type",-1,"state",["state"],false,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["AbstractPreparedDetectorAcquisitionLifecycle","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["GlobalShutterAcquisitionDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["GlobalShutterAcquisitionState","mutable_struct",9,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedGlobalShutterAcquisition","struct",9,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedGlobalShutterAcquisitionToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/device_batching.jl"
+owner = "Plant"
+entries = [
+    ["_PreparedDeviceBatchWFSOpticalPlan","type_alias",-1,"prepared",["prepared_owner_interface"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedDevicePathBatchImplementation","type_alias",-1,"prepared",["prepared_owner_interface"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedDirectImagingDevicePathBatch","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedWFSDevicePathBatch","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/direct_measurement_events.jl"
+owner = "Plant"
+entries = [
+    ["DirectMeasurementAcquisitionDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["DirectMeasurementAcquisitionState","mutable_struct",8,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedDirectMeasurementAcquisition","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/effective_command_routes.jl"
+owner = "Plant"
+entries = [
+    ["_DirectEffectiveCommandPublicationRouteState","mutable_struct",5,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_EffectiveCommandPublicationRoutesState","struct",1,"state",["state"],false,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedDirectEffectiveCommandPublicationRoute","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedEffectiveCommandPublicationRoute","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["_PreparedEffectiveCommandPublicationRoutes","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedRemoteEffectiveCommandPublicationRoute","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_RemoteEffectiveCommandPublicationRouteState","mutable_struct",8,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/errors.jl"
+owner = "Plant"
+entries = [
+    ["PlantDefinitionError","struct",3,"definition",["support"],false,false,"internal",false,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/event_composition.jl"
+owner = "Plant"
+entries = [
+    ["AbstractAcquisitionStartDefinition","abstract_type",-1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["AcquisitionEventDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["OpticalSampleDefinition","struct",3,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["PlantEventLoopDefinition","struct",4,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["PlantEventLoopState","mutable_struct",13,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PlantEventLoopWorkspace","mutable_struct",15,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedDevicePathBatchOwner","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPathExecutionGroup","struct",18,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPlantEventLoop","struct",18,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_AcquisitionEventLifecycleState","type_alias",-1,"state",["state"],false,true,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_AcquisitionStartDefinition","type_alias",-1,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-06"],
+    ["_NoPreparedTriggerTopology","struct",0,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_NoTriggerTopologyState","struct",0,"state",["state"],false,false,"internal",true,"backend_parameterized",false,"PE-06"],
+    ["_NoTriggerTopologyWorkspace","struct",0,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_OpticalPathBatchWorkspace","mutable_struct",11,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PlantEventLoopStateBinding","mutable_struct",0,"state",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PlantEventLoopWorkspaceBinding","mutable_struct",0,"workspace",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedAcquisitionEventLifecycle","type_alias",-1,"prepared",["prepared_owner_interface"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedControllableOpticPathCouplingGroup","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedDevicePathBatchOwnerBinding","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedDevicePathBatchOwnerToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedPathExecutionGroupAcquisition","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedPlantEventAcquisition","struct",13,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedPlantEventCommandEndpoint","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/handoffs.jl"
+owner = "Plant"
+entries = [
+    ["PreparedCrossDomainHandoff","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_HandoffSlotState","mutable_struct",3,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/illumination.jl"
+owner = "Plant"
+entries = [
+    ["PreparedIlluminationEntry","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedUniformIntensityIllumination","struct",4,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedIlluminationEntryToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/mixed_serial_event_loop.jl"
+owner = "Plant"
+entries = [
+    ["MixedResourcePlantEventLoopState","mutable_struct",9,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["MixedResourcePlantEventLoopWorkspace","mutable_struct",9,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedMixedResourcePlantEventLoop","struct",9,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_AbstractPreparedMixedSerialEventAcquisition","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["_PreparedMixedResourcePlantEventLoopBinding","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedMixedSerialEventAcquisition","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialEventCommand","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialPathSchedule","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialTriggeredAcquisition","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/mixed_serial_execution.jl"
+owner = "Plant"
+entries = [
+    ["_AbstractMixedSerialPathWorkspace","abstract_type",-1,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_AbstractPreparedMixedSerialPath","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["_MixedSerialBatchWorkspace","mutable_struct",7,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_MixedSerialExecutionState","mutable_struct",5,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_MixedSerialExecutionWorkspace","struct",5,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_MixedSerialPathWorkspace","struct",1,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialCommandDependency","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialControllableOpticApplication","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialExecution","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedMixedSerialExecutionBinding","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedMixedSerialPath","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/partitions.jl"
+owner = "Plant"
+entries = [
+    ["PreparedAtmosphereAuthority","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPlantPartitions","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedTargetPartition","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedAtmosphereAuthorityToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedPlantPartitionsToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedTargetPartitionRNGs","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedTargetPartitionToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/path_input_publications.jl"
+owner = "Plant"
+entries = [
+    ["PreparedDirectPupilOPDPublicationRoute","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPupilOPDPublicationRoute","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["PreparedRemotePupilOPDPublicationRoute","struct",9,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_DirectPupilOPDPublicationState","mutable_struct",4,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_RemotePupilOPDPublicationState","mutable_struct",7,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/preparation.jl"
+owner = "Plant"
+entries = [
+    ["PreparedAcquisitionOwner","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedAcquisitionSelection","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPathExecutor","struct",11,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPlant","struct",13,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPupilOPDMaterialization","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedAcquisitionOwnerToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedAcquisitionSelectionToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedPathExecutorToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedPlantToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedPupilOPDMaterializationToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/product_providers.jl"
+owner = "Plant"
+entries = [
+    ["AcquisitionProductContract","struct",3,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["AcquisitionProducts","struct",3,"product",["product"],false,false,"caller_visible",false,"backend_parameterized",false,"PE-06"],
+    ["CyclicReplayProviderParams","struct",1,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["CyclicReplayProviderState","mutable_struct",1,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedAcquisitionProvider","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedCopiedSyntheticProvider","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedCyclicReplayProvider","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedFullOpticalProvider","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedUnchangedSyntheticProvider","struct",0,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_AbsentProductContract","struct",0,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_AcquisitionProductContractToken","struct",0,"product",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_ArrayProductContract","struct",4,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_OpticalProductContract","struct",2,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedAcquisitionProviderToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_RefProductContract","struct",1,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_WFSMeasurementProductContract","struct",3,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_WFSObservationProductContract","struct",3,"product",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/pupil_footprint_coupling.jl"
+owner = "Plant"
+entries = [
+    ["PreparedDirectPupilSurfaceCoupling","struct",1,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedIdentityPupilFootprintCoupling","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPupilFootprintCoupling","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedPupilFootprintCouplingToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/randomness.jl"
+owner = "Plant"
+entries = [
+    ["PreparedAtmosphereRNGs","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedOwnerRNGs","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedPlantRNGs","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedRNGStream","struct",3,"prepared",["state","prepared_owner"],false,true,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/reduced_order.jl"
+owner = "Plant"
+entries = [
+    ["HarmonicDisturbanceState","mutable_struct",3,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedHarmonicDisturbance","struct",4,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["PreparedLinearReducedOrderEventProvider","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedLinearReducedOrderProvider","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedReducedOrderCommandResponse","struct",6,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedArrayReducedOrderEventResponse","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedReducedOrderEventResponse","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["_PreparedScalarReducedOrderEventResponse","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/rolling_frame_transfer_events.jl"
+owner = "Plant"
+entries = [
+    ["FrameTransferAcquisitionDefinition","struct",2,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["FrameTransferAcquisitionState","mutable_struct",13,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedFrameTransferAcquisition","struct",9,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedRollingShutterAcquisition","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["RollingShutterAcquisitionDefinition","struct",2,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["RollingShutterAcquisitionState","mutable_struct",9,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/sampled_aberrations.jl"
+owner = "Plant"
+entries = [
+    ["PreparedSampledAberration","struct",3,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["PreparedSampledAberrationPathBindings","struct",4,"prepared",["plan","prepared_owner"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedSampledAberrationApplication","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedSampledAberrationPathBindingsToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedSampledAberrationPathPlan","struct",1,"plan",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
+    ["_PreparedSampledAberrationToken","struct",0,"prepared",["binding_token"],false,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/scheduling.jl"
+owner = "Plant"
+entries = [
+    ["EventGeneratorDefinition","struct",5,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["EventSchedulerState","mutable_struct",8,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["EventSchedulerWorkspace","mutable_struct",6,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedEventScheduler","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/target_local_resources.jl"
+owner = "Plant"
+entries = [
+    ["PreparedTargetLocalAcquisitionResources","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["PreparedTargetLocalPathResources","struct",9,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedTargetLocalAcquisitionResourcesToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+    ["_PreparedTargetLocalPathResourcesToken","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/plant/triggers.jl"
+owner = "Plant"
+entries = [
+    ["PreparedTriggerTopology","struct",16,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["TriggerConsumerDefinition","struct",2,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TriggerLinkDefinition","struct",6,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TriggerSourceDefinition","struct",6,"definition",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TriggerTopologyState","mutable_struct",9,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["TriggerTopologyWorkspace","mutable_struct",13,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedTriggerConsumer","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedTriggerFaultSample","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedTriggerLink","struct",10,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+    ["_PreparedTriggerSource","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
+]
+
+[[type_inventory.files]]
+path = "src/tomography/parameters.jl"
+owner = "Tomography"
+entries = [
+    ["LGSAsterismParams","struct",4,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["LGSWFSParams","struct",7,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TomographyAtmosphereParams","struct",8,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TomographyDMParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["TomographyParams","struct",3,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/bioedge/setup.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["BioEdgeAcquisitionState","mutable_struct",3,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["BioEdgeEstimatorParams","struct",6,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["BioEdgeEstimatorState","mutable_struct",23,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["PreparedBioEdgePropagation","mutable_struct",18,"prepared",["plan","workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/bioedge/stages.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedBioEdgeEstimator","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedBioEdgeOpticalBundleFormation","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedBioEdgeOpticalFormation","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/curvature.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["CurvatureAcquisitionState","mutable_struct",1,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["CurvatureEstimatorState","mutable_struct",10,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["CurvatureWFSParams","struct",8,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["PreparedCurvaturePropagation","mutable_struct",13,"prepared",["plan","workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/curvature/stages.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["AbstractPreparedCurvatureObservationMapping","abstract_type",-1,"prepared",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["PreparedCurvatureEstimator","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedCurvatureOpticalFormation","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedCurvaturePackedChannelAcquisition","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedCurvaturePackedFrameAcquisition","struct",6,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/focal_plane_modulation.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["AbstractPreparedFourPupilLGS","abstract_type",-1,"prepared",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["NoPreparedFourPupilLGS","struct",0,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-05"],
+    ["PreparedFourPupilElongation","struct",2,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-05"],
+    ["PreparedFourPupilSodiumProfile","struct",1,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/grouped.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["AbstractGroupedAccumulationPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["GroupedDirectAccumulatePlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["GroupedStackReducePlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["GroupedStaged2DPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/lift.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["LiFTForwardWorkspace","struct",16,"workspace",["workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-05"],
+    ["LiFTParams","struct",4,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["LiFTState","struct",9,"state",["workspace","product"],false,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["PreparedLiFTForwardModel","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/pyramid/setup.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedPyramidPropagation","mutable_struct",17,"prepared",["plan","workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-05"],
+    ["PyramidAcquisitionState","mutable_struct",3,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["PyramidEstimatorParams","struct",7,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["PyramidEstimatorState","mutable_struct",21,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/pyramid/stages.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedPyramidEstimator","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedPyramidOpticalBundleFormation","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedPyramidOpticalFormation","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/shack_hartmann/setup.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["AbstractShackHartmannWFSSensingPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["ShackHartmannAcquisitionState","mutable_struct",4,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["ShackHartmannEstimatorState","mutable_struct",5,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["ShackHartmannWFSBatchedPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["ShackHartmannWFSDeviceStatsPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["ShackHartmannWFSParams","struct",2,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+    ["ShackHartmannWFSRocmHostStatsPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["ShackHartmannWFSRocmSafePlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+    ["ShackHartmannWFSScalarPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/shack_hartmann/stages.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedShackHartmannEstimator","struct",5,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedShackHartmannOpticalBundleFormation","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedShackHartmannOpticalFormation","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/stage_contracts.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedWFSCountingAcquisition","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedWFSDetectorAcquisition","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedWFSMultipleDetectorAcquisition","struct",3,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/subapertures.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["SubapertureLayoutState","mutable_struct",1,"state",["state"],true,true,"internal",false,"backend_parameterized",true,"PE-05"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/zernike.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedZernikePropagation","mutable_struct",11,"prepared",["plan","workspace"],true,false,"internal",false,"backend_parameterized",true,"PE-05"],
+    ["ZernikeAcquisitionState","mutable_struct",1,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["ZernikeEstimatorState","mutable_struct",14,"state",["state","workspace","product"],true,true,"caller_visible",false,"backend_parameterized",true,"PE-05"],
+    ["ZernikeWFSParams","struct",9,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
+]
+
+[[type_inventory.files]]
+path = "src/wfs/zernike/stages.jl"
+owner = "WavefrontSensors"
+entries = [
+    ["PreparedZernikeEstimator","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+    ["PreparedZernikeOpticalFormation","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
+]
+
+[direct_memory]
+policy = "ratchet"
+columns = ["category","scope","binding","baseline_line","count","hot_path","backend_relevance","replacement"]
+baseline_total = 344
+zero_tolerance_gate = "PE-07"
+interpretation = "AST references in package and extension implementation; comments, strings, tests, benchmarks, and dependency internals are excluded"
+
+[[direct_memory.files]]
+path = "src/atmosphere/definitions.jl"
+owner = "Atmospheres"
+entries = [
+    ["constructor","_cold_atmosphere_layer_definitions","layers",112,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/atmosphere/direction_batch.jl"
+owner = "Atmospheres"
+entries = [
+    ["constructor","_copy_layer_bindings","bindings",248,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_copy_source_bindings","bindings",240,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_copy_source_geometry_bindings","bindings",225,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","AtmosphereDirectionBatchParams","<constraint>",90,3,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["type_constraint","AtmosphereDirectionBatchParams","<type-parameter>",62,3,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/optics/direct_imaging_batch.jl"
+owner = "Optics"
+entries = [
+    ["constructor","_direct_imaging_batch_inputs","storage",302,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_direct_imaging_batch_sources","frozen",222,2,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_direct_imaging_batch","fields",471,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_direct_imaging_batch","formation_plans",472,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_direct_imaging_batch","samples",474,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_repeat_direct_imaging_batch_input","storage",288,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["type_constraint","_FixedDirectImagingBatchVector","<type-parameter>",60,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/command_admission.jl"
+owner = "Plant"
+entries = [
+    ["constructor","CommandEndpointState","<expression>",661,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","CommandEndpointState","accepted_sequences",659,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","CommandEndpointState","slots",657,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_command_disposition_workspace","<expression>",714,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_command_payload_slots","<expression>",590,2,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_command_payload_slots","values",598,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","CommandDispositionWorkspace","dispositions",690,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","CommandEndpointState","accepted_sequences",638,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","CommandEndpointState","calendar",637,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","CommandEndpointState","slots",636,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_ArrayCommandPayloadSlots","values",584,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_ScalarCommandPayloadSlots","staging",579,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_ScalarCommandPayloadSlots","values",578,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/command_authority.jl"
+owner = "Plant"
+entries = [
+    ["constructor","CommandAuthorityWorkspace","dispositions",261,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_command_authority_state","application_states",217,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_command_authority_state","endpoint_states",216,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_command_authority_state","publication_timestamps",221,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_command_authority_state","sequences",219,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","CommandAuthorityState","publication_sequences",53,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","CommandAuthorityState","publication_timestamps",54,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/command_fanout.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_prepare_command_fanout_authority_workspace","dispositions",749,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_commit_selected_command_authority!","<expression>",1502,2,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_commit_selected_command_authority!","publication_timestamps",1513,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_commit_selected_command_authority!","sequences",1513,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_commit_selected_safe_command_authority!","<expression>",1544,2,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_commit_selected_safe_command_authority!","publication_timestamps",1555,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_commit_selected_safe_command_authority!","sequences",1555,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prevalidate_selected_command_silence!","<expression>",1026,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prevalidate_selected_command_silence!","sequences",1036,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_selected_command_fanout_ready","<expression>",994,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_selected_command_fanout_ready","sequences",999,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/command_publications.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_partition_command_endpoint_configurations","prepared",933,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_target_local_command_endpoints","endpoints",1020,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_target_local_command_endpoints","physical_initials",1024,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_target_local_command_endpoints","states",1022,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_target_local_controllable_optic_owners","owners",1121,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/controllable_optics.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_optic_binding_memory","result",495,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_controllable_optics","optics",407,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_plant_command_endpoints","endpoints",374,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedControllableOpticPathBindings","binding_offsets",475,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedControllableOpticPathBindings","group_offsets",476,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedControllableOpticPathBindings","optic_slots",477,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedControllableOpticPathBindings","path_ids",473,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedControllableOpticPathBindings","path_slots",474,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedControllableOpticPathBindings","plane_groups",478,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedControllableOpticPathBindings","binding_offsets",480,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedControllableOpticPathBindings","group_offsets",480,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedControllableOpticPathBindings","optic_slots",480,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedControllableOpticPathBindings","path_ids",480,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedControllableOpticPathBindings","path_slots",480,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedControllableOpticPathBindings","plane_groups",480,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/definitions.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_definition_registry","memory",587,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/detector_acquisition_events.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_empty_detector_read_offsets","<expression>",174,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_even_detector_read_offsets","offsets",181,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedGlobalShutterAcquisition","read_offsets",89,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedGlobalShutterAcquisition","read_offsets",91,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_detector_event_products!","<expression>",245,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_detector_event_products!","offsets",251,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/device_batching.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_collect_device_path_batch_members","inputs",514,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_collect_device_path_batch_members","results",515,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_collect_device_path_batch_members","sources",516,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_collect_wfs_device_path_batch_members","geometry_sources",653,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_collect_wfs_device_path_batch_members","inputs",651,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_collect_wfs_device_path_batch_members","results",652,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_copy_device_path_batch_slots","copied",441,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_device_path_batch_stack_views","views",452,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_device_path_batch_owners","owners",770,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_device_path_batch_owners","path_owner_slots",771,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_collect_device_path_batch_members","groups",501,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_collect_device_path_batch_members","slots",501,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_collect_wfs_device_path_batch_members","groups",636,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_collect_wfs_device_path_batch_members","slots",636,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_device_path_batch_owner","groups",620,2,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_device_path_batch_owners","groups",749,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_direct_imaging_device_path_batch_owner","groups",547,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["type_constraint","_PreparedDirectImagingDevicePathBatch","<type-parameter>",54,3,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["type_constraint","_PreparedWFSDevicePathBatch","<type-parameter>",130,4,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/event_composition.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_event_command_states","applications",1762,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_event_command_states","endpoints",1760,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_event_controllable_optic_states","states",1795,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_optical_path_batch_workspace","<expression>",1895,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_optical_path_batch_workspace","status",1886,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_state","acquisition_states",1823,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_state","command_shadow_transactions",1819,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_state","path_sampled",1829,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_state","product_ready_timestamps",1834,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_state","product_sequences",1831,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_workspace","command_endpoints",1911,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_workspace","controllable_optics",1919,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_plant_event_loop_workspace","due_paths",1926,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_plant_event_loop_workspace","workspace",1929,5,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_event_acquisitions","acquisitions",1594,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_event_autonomous_optics","bindings",1445,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_event_command_endpoints","endpoints",1013,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_event_controllable_optics","optics",993,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_event_path_optic_couplings","<expression>",1160,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_event_path_optic_couplings","couplings",1157,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_event_path_optic_couplings","group_memory",1212,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_event_sampled_aberrations","aberrations",1002,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_path_execution_group_acquisitions","acquisitions",1245,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_path_execution_group_autonomous_optic_slots","slots",1267,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_path_execution_groups","groups",1287,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepared_event_actions","actions",982,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopState","acquisitions",1732,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PlantEventLoopState","command_applications",1729,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopState","command_endpoints",1728,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopState","command_shadow_transactions",1730,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopState","controllable_optics",1731,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PlantEventLoopState","path_sampled",1733,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopState","product_ready_timestamps",1735,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopState","product_sequences",1734,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","command_dispositions",1864,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","command_endpoints",1862,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","controllable_optics",1863,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PlantEventLoopWorkspace","due_paths",1871,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","transaction_admissions",1867,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","transaction_claims",1868,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","transaction_endpoint_slots",1866,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PlantEventLoopWorkspace","transaction_staged",1869,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedDevicePathBatchOwner","group_slots",447,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPathExecutionGroup","acquisitions",398,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedPathExecutionGroup","autonomous_optic_slots",399,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPathExecutionGroup","optic_coupling_groups",396,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPathExecutionGroup","optic_couplings",395,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","acquisitions",491,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedPlantEventLoop","actions",481,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","autonomous_optics",492,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","command_endpoints",487,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","device_path_batch_owners",489,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","optics",482,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","path_device_batch_owner_slots",490,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","path_groups",488,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantEventLoop","sampled_aberrations",484,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_OpticalPathBatchWorkspace","due_group_slots",225,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_OpticalPathBatchWorkspace","group_status",227,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedDevicePathBatchOwner","group_slots",450,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_apply_due_path_controllable_optics!","couplings",4346,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","_apply_due_path_controllable_optics!","optics",4346,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_apply_due_path_controllable_optics!","states",4346,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","_due_full_optical_path","due_paths",4510,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_preflight_due_path_consumers","due_paths",4050,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_validate_due_path_materializations!","due_paths",4068,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/handoffs.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_copy_handoff_slots","copied",196,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_handoff_backend_states","states",400,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","prepare_cross_domain_handoff","publications",510,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_cross_domain_handoff","states",511,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedCrossDomainHandoff","backend_states",152,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedCrossDomainHandoff","destination_slots",151,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedCrossDomainHandoff","publications",153,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedCrossDomainHandoff","source_slots",150,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedCrossDomainHandoff","states",154,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","_prepare_handoff_backend_states","destination_slots",383,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_handoff_backend_states","source_slots",383,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_handoff_slot_storage","slots",300,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_nonaliasing_handoff_slots","destination_slots",327,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_nonaliasing_handoff_slots","source_slots",327,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/mixed_serial_event_loop.jl"
+owner = "Plant"
+entries = [
+    ["constructor","MixedResourcePlantEventLoopState","acquisitions",560,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","MixedResourcePlantEventLoopState","path_sampled",566,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","MixedResourcePlantEventLoopState","product_ready_timestamps",571,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","MixedResourcePlantEventLoopState","product_sequences",568,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","MixedResourcePlantEventLoopWorkspace","<expression>",613,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_mixed_serial_path_acquisition_slots","<expression>",323,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_mixed_serial_event_acquisitions","acquisitions",299,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_mixed_serial_event_commands","commands",353,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_mixed_serial_path_schedules","paths",331,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_mixed_serial_triggered_acquisitions","<expression>",400,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","MixedResourcePlantEventLoopState","acquisitions",83,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","MixedResourcePlantEventLoopState","path_sampled",84,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","MixedResourcePlantEventLoopState","product_ready_timestamps",86,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","MixedResourcePlantEventLoopState","product_sequences",85,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","MixedResourcePlantEventLoopWorkspace","command_dispositions",109,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedMixedResourcePlantEventLoop","acquisitions",66,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedMixedResourcePlantEventLoop","actions",63,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedMixedResourcePlantEventLoop","commands",64,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedMixedResourcePlantEventLoop","paths",65,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedMixedResourcePlantEventLoop","triggered_acquisitions",67,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_PreparedMixedSerialPathSchedule","acquisition_slots",22,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_integrate_due_mixed_serial_acquisitions!","due",1706,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_mixed_serial_path_acquisition_slots","acquisitions",314,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","_preflight_due_mixed_serial_acquisitions!","due",1685,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_mixed_serial_path_schedules","acquisitions",326,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/mixed_serial_execution.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_mixed_serial_prepared_optics","optics",122,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_mixed_serial_execution","paths",345,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_mixed_serial_execution_workspace","<expression>",406,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_mixed_serial_execution_workspace","path_workspaces",391,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_MixedSerialExecutionWorkspace","due_paths",79,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_MixedSerialExecutionWorkspace","paths",80,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","_PreparedMixedSerialExecution","paths",41,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","_preflight_mixed_serial_due_paths","due",719,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_mixed_serial_command_dependencies!","<expression>",682,2,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_mixed_serial_command_dependencies!","publication_timestamps",691,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_mixed_serial_command_dependencies!","sequences",691,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_select_mixed_serial_due_paths!","<expression>",472,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_select_mixed_serial_due_paths!","due",448,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/partition_assignments.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_partition_registry","storage",98,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/partitions.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_partition_rng_replay_metadata","owned",641,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_partition_sampled_aberrations","prepared",386,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_target_local_acquisitions","acquisitions",348,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_target_local_paths","paths",310,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_target_local_acquisition_rng_owner_bindings","groups",502,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_target_local_path_rng_owner_bindings","groups",490,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_plant_partitions","partition_binding_groups",716,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_plant_partitions","partitions",746,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_plant_partitions","unbound",702,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","_PreparedTargetPartitionRNGs","acquisitions",72,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","_PreparedTargetPartitionRNGs","paths",71,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/preparation.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_acquisition_rng_owner_bindings","groups",1608,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_canonical_selected_acquisitions","result",1811,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_canonical_selected_paths","result",1831,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_path_rng_owner_bindings","groups",1597,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_acquisition_owners","acquisitions",1585,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_path_executors","paths",1566,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_selected_acquisition_rngs","result",1879,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_selected_path_rngs","result",1860,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_selected_sampled_aberration_path_plans","plans",1892,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedAcquisitionSelection","acquisition_rngs",1747,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedAcquisitionSelection","acquisitions",1744,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedAcquisitionSelection","path_rngs",1746,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedAcquisitionSelection","paths",1743,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedPlant","acquisitions",1316,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedPlant","command_endpoints",1314,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlant","controllable_optics",1310,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedPlant","paths",1315,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","PreparedAcquisitionSelection","acquisition_rngs",1749,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedAcquisitionSelection","acquisitions",1749,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","PreparedAcquisitionSelection","path_rngs",1749,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedAcquisitionSelection","paths",1749,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","PreparedPlant","acquisitions",1319,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","PreparedPlant","command_endpoints",1319,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedPlant","controllable_optics",1319,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","PreparedPlant","paths",1319,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/product_providers.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_owned_replay_corpus","owned",569,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["type_constraint","PreparedCyclicReplayProvider","<type-parameter>",550,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/randomness.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_prepare_owner_rng_groups","groups",330,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_rng_replay_metadata","owned",544,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedPlantRNGs","acquisitions",130,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedPlantRNGs","paths",129,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/resource_facts.jl"
+owner = "Plant"
+entries = [
+    ["signature_type","_memory_structural_array_bytes","memory",356,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","structural_array_bytes","memory",363,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/resource_facts_acquisition.jl"
+owner = "Plant"
+entries = [
+    ["signature_type","_acquisition_optional_array_bytes","Memory",37,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_acquisition_optional_array_bytes","memory",28,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/resource_facts_runtime.jl"
+owner = "Plant"
+entries = [
+    ["signature_type","_structural_memory_element_bytes","memory",24,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/sampled_aberrations.jl"
+owner = "Plant"
+entries = [
+    ["constructor","_prepare_sampled_aberration_path_bindings","couplings",339,1,false,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["constructor","_prepare_sampled_aberrations","prepared",155,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedSampledAberrationPathBindings","aberration_slots",179,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedSampledAberrationPathBindings","binding_offsets",178,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedSampledAberrationPathBindings","couplings",180,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["field_type","PreparedSampledAberrationPathBindings","path_ids",177,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedSampledAberrationPathBindings","aberration_slots",182,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedSampledAberrationPathBindings","binding_offsets",182,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","PreparedSampledAberrationPathBindings","couplings",182,1,true,"host_ownership_storage","concrete execution-family groups or a purpose-built owner"],
+    ["signature_type","PreparedSampledAberrationPathBindings","path_ids",182,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/scheduling.jl"
+owner = "Plant"
+entries = [
+    ["constructor","EventSchedulerState","cursors",243,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","EventSchedulerWorkspace","<expression>",275,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_copy_event_generator_definitions","owned",105,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","EventSchedulerState","cursors",231,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","EventSchedulerWorkspace","due_slots",267,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedEventScheduler","definitions",71,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_canonicalize_event_generator_definitions!","definitions",139,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_require_unique_event_ordinals","definitions",114,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[[direct_memory.files]]
+path = "src/plant/triggers.jl"
+owner = "Plant"
+entries = [
+    ["constructor","TriggerTopologyState","has_last_delivery",474,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyState","last_delivery",473,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyState","link_offsets",472,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyState","pending",480,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyState","pending_active",481,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyState","sequences",470,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyState","source_offsets",471,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","TriggerTopologyWorkspace","<expression>",508,9,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_trigger_child_registry","consumer_offsets",1104,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_trigger_child_registry","consumer_slots",1115,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_trigger_child_registry","link_offsets",1103,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","_prepare_trigger_child_registry","link_slots",1114,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_trigger_topology","prepared_consumers",1529,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_trigger_topology","prepared_fault_ids",1549,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_trigger_topology","prepared_links",1525,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_trigger_topology","prepared_sources",1482,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["constructor","prepare_trigger_topology","prepared_trace_entries",1546,1,false,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","consumer_child_offsets",323,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","consumer_child_slots",324,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","consumers",320,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","fault_ids",326,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","link_child_offsets",321,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","link_child_slots",322,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","links",319,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","sources",318,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","PreparedTriggerTopology","trace_entries",325,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","has_last_ordinary_delivery",460,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","last_ordinary_delivery",459,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","link_phase_offsets",458,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","pending",461,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","pending_active",462,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","source_phase_offsets",457,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyState","source_sequences",456,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","consumer_occurrences",495,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","fault_observations",501,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","link_samples",497,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","link_selected",498,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","next_has_last_ordinary_delivery",500,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","next_last_ordinary_delivery",499,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","next_link_phase_offsets",496,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","propagation",491,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["field_type","TriggerTopologyWorkspace","staged_deliveries",493,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_trigger_child_registry","consumers",1086,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+    ["signature_type","_prepare_trigger_child_registry","links",1086,1,true,"host_ownership_storage","FixedSizeArray{ConcreteT} for host ownership metadata"],
+]
+
+[stored_any]
+policy = "ratchet"
+columns = ["category","scope","binding","baseline_line","count","hot_path","replacement"]
+baseline_total = 25
+zero_tolerance_gate = "PE-07"
+interpretation = "stored fields, erased collection/reference signatures and returns, explicit or implicit erased constructors and array literals, and prepared Any returns; unconstrained dispatch wildcards are excluded"
+
+[[stored_any.files]]
+path = "src/core/config.jl"
+owner = "Root"
+entries = [
+    ["erased_storage_constructor","config_dict","out",11,3,false,"concrete configuration schema"],
+]
+
+[[stored_any.files]]
+path = "src/plant/command_fanout.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","_prepare_command_fanout","lanes",104,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[[stored_any.files]]
+path = "src/plant/controller_routing.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","prepare_controller_output_routing","prepared",282,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[[stored_any.files]]
+path = "src/plant/device_batching.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","_prepare_device_path_batch_owners","keys",755,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[[stored_any.files]]
+path = "src/plant/event_composition.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","_prepare_event_acquisition_parts","lifecycles",1566,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_prepare_event_acquisition_parts","owners",1565,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_prepare_event_acquisition_parts","products",1567,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_prepare_event_acquisition_parts","rngs",1569,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_prepare_event_acquisition_parts","sample_providers",1568,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_sorted_acquisition_event_definitions","values",604,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_sorted_autonomous_periodic_optic_definitions","values",616,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_sorted_optical_sample_definitions","values",593,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["erased_storage_constructor","_event_controllable_optic_states","states",1795,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["erased_storage_constructor","_plant_event_loop_workspace","controllable_optics",1919,1,false,"type parameter or concrete execution-family owner"],
+    ["field_stored_any","PlantEventLoopState","controllable_optics",1731,1,true,"type parameter or concrete execution-family owner"],
+    ["field_stored_any","PlantEventLoopWorkspace","controllable_optics",1863,1,true,"type parameter or concrete execution-family owner"],
+    ["field_stored_any","PreparedDevicePathBatchOwner","implementation",448,1,true,"type parameter or concrete execution-family owner"],
+    ["signature_erased_storage","_apply_due_path_controllable_optics!","states",4346,1,true,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[[stored_any.files]]
+path = "src/plant/mixed_serial_execution.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","_prepare_mixed_serial_controllable_optics","applications",230,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["any_array_literal","_prepare_mixed_serial_controllable_optics","dependencies",231,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+    ["signature_erased_storage","_append_mixed_serial_command_dependencies!","dependencies",206,1,true,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[[stored_any.files]]
+path = "src/plant/sampled_aberrations.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","_prepare_sampled_aberration_path_plan","applications",425,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[[stored_any.files]]
+path = "src/plant/triggers.jl"
+owner = "Plant"
+entries = [
+    ["any_array_literal","_collect_trigger_definition_values","result",1017,1,false,"concrete tuple or typed cold builder sealed during preparation"],
+]
+
+[fixed_size_arrays]
+core_dependency = false
+characterized_version = "1.3.0"
+project = "benchmarks/fixed_size_arrays/Project.toml"
+contract = "benchmarks/contracts/fixed_size_arrays.toml"
+artifact = "benchmarks/results/prepared_execution/2026-08-02-fixed-size-arrays.toml"
+adoption_gate = "first migration slice that uses FixedSizeArray"
+backing_policy = "dependency internals are neither named nor asserted"
+element_policy = "armed homogeneous storage must require a concrete element type"
+
+[adaptive_optics_hil]
+repository = "https://github.com/DarrylGamroth/AdaptiveOpticsHIL.jl.git"
+source_revision = "4ab3c1dc9dae81c34aa4aa6422216e1dab71fcc5"
+adaptive_optics_sim_pin = "f12ae7beceaf460fb6953d4bb07874be5197d4ff"
+import_inventory = "test/contracts/prepared_execution_hil_impact.toml"
+affected_owner_types = ["PreparedPlantEventLoop","PlantEventLoopState","PlantEventLoopWorkspace","PreparedPathExecutor","PreparedCommandEndpoint","CommandEndpointState","CommandDispositionWorkspace","AcquisitionProductContract","AcquisitionProducts"]
+construction_assumptions = ["A plant-backed PreparedCommandBridge retains one exact PreparedPlantEventLoop and constructs PlantEventLoopState and PlantEventLoopWorkspace from that same owner","PreparedExecutionOwnerExecutor specializes on and retains the exact PreparedPlantEventLoop, PlantEventLoopState, and PlantEventLoopWorkspace types and identities for one run","HIL command ports retain PreparedCommandEndpoint, CommandEndpointState, and CommandDispositionWorkspace ownership boundaries","HIL acquisition publishers validate AcquisitionProductContract before copying complete AcquisitionProducts into transport-neutral lease storage","HIL test and benchmark fixtures extend preparation seams and directly construct PreparedPathExecutor values; PE-08 must update these callers without compatibility adapters"]
+
+[evidence_index]
+classes = ["numerical","inference","allocation","storage","package_load","cpu","cuda","amdgpu"]
+
+[[evidence_index.entries]]
+class = "numerical"
+path = "test/reference_data_gate0/manifest.toml"
+claim_limit = "deterministic numerical fixture index only; individual model tolerances govern"
+
+[[evidence_index.entries]]
+class = "inference"
+path = "test/testsets/plant_topology_growth.jl"
+claim_limit = "representative prepared Plant topology inference, not every public call"
+
+[[evidence_index.entries]]
+class = "allocation"
+path = "benchmarks/contracts/gate6_topology_growth.toml"
+claim_limit = "Gate 6 prepared Plant workload only; coverage instrumentation is excluded"
+
+[[evidence_index.entries]]
+class = "storage"
+path = "benchmarks/results/gate6/2026-07-25-topology-growth.toml"
+claim_limit = "Gate 6 topology-growth representation before PE migrations"
+
+[[evidence_index.entries]]
+class = "package_load"
+path = "benchmarks/results/namespace/2026-07-29-namespace-latency.toml"
+claim_limit = "descriptive warm-cache package-load baseline, not a deadline"
+
+[[evidence_index.entries]]
+class = "cpu"
+path = "benchmarks/results/gate7/2026-07-26-gate7-local-cpu.toml"
+claim_limit = "single-host Gate 7 workload only"
+
+[[evidence_index.entries]]
+class = "cuda"
+path = "benchmarks/results/gate7/2026-07-26-gate7-wsl-cuda.toml"
+claim_limit = "single WSL CUDA target and Gate 7 workload only"
+
+[[evidence_index.entries]]
+class = "amdgpu"
+path = "benchmarks/results/gate7/2026-07-26-gate7-local-amdgpu.toml"
+claim_limit = "single local AMDGPU target and Gate 7 workload only"

--- a/test/prepared_execution_contract_helpers.jl
+++ b/test/prepared_execution_contract_helpers.jl
@@ -1,0 +1,614 @@
+struct PETypeDeclaration
+    path::String
+    name::String
+    declaration::String
+    mutable::Bool
+    field_count::Int
+    line::Int
+end
+
+struct PEDebtSite
+    path::String
+    category::String
+    scope::String
+    binding::String
+    line::Int
+end
+
+const PE_VOCABULARY = Set((
+    "definition",
+    "definitions",
+    "params",
+    "parameters",
+    "plan",
+    "prepared",
+    "state",
+    "workspace",
+    "product",
+    "products",
+    "strategy",
+))
+
+const PE_NONSTORAGE_SIGNATURE_ROOTS = Set((
+    :Tuple,
+    :NamedTuple,
+    :Vararg,
+    :Type,
+    :Val,
+    :Union,
+))
+
+const PE_STORAGE_TYPE_ROOTS = Set((
+    :Array,
+    :Vector,
+    :Matrix,
+    :Memory,
+    :GenericMemory,
+    :AtomicMemory,
+    :AbstractArray,
+    :AbstractVector,
+    :AbstractMatrix,
+    :DenseArray,
+    :DenseVector,
+    :DenseMatrix,
+    :FixedSizeArray,
+    :FixedSizeVector,
+    :FixedSizeMatrix,
+    :Ref,
+    :RefValue,
+    :Dict,
+    :IdDict,
+    :WeakKeyDict,
+    :Set,
+))
+
+const PE_IMPLICIT_ANY_EMPTY_CONSTRUCTORS = Set((
+    :Dict,
+    :IdDict,
+    :WeakKeyDict,
+    :Set,
+))
+
+function pe_source_paths(root::AbstractString)
+    paths = String[]
+    for relative_root in ("src", "ext")
+        directory = joinpath(root, relative_root)
+        isdir(directory) || continue
+        for (parent, _, files) in walkdir(directory)
+            append!(paths, joinpath(parent, file) for file in files
+                if endswith(file, ".jl"))
+        end
+    end
+    return sort!(paths)
+end
+
+function pe_camel_tokens(name::AbstractString)
+    tokens = String[]
+    for component in split(strip(name, '_'), '_')
+        for matched in eachmatch(
+            r"[A-Z]+(?=[A-Z][a-z]|\d|$)|[A-Z]?[a-z]+|\d+",
+            component,
+        )
+            push!(tokens, lowercase(matched.match))
+        end
+    end
+    return tokens
+end
+
+pe_has_vocabulary(name::AbstractString) =
+    !isdisjoint(Set(pe_camel_tokens(name)), PE_VOCABULARY)
+
+function pe_type_name(expression)
+    expression isa Symbol && return expression
+    expression isa QuoteNode && expression.value isa Symbol &&
+        return expression.value
+    expression isa Expr || return nothing
+    if expression.head in (:curly, :(<:), :(>:), :(::))
+        return pe_type_name(first(expression.args))
+    elseif expression.head == :.
+        return pe_type_name(last(expression.args))
+    end
+    return nothing
+end
+
+function pe_declaration_name(expression)
+    expression isa Symbol && return expression
+    expression isa Expr || return nothing
+    if expression.head in (:curly, :(<:), :(::))
+        return pe_declaration_name(first(expression.args))
+    end
+    return nothing
+end
+
+function pe_is_type_alias_rhs(expression)
+    expression isa Symbol && return true
+    expression isa Expr || return false
+    return expression.head in (:curly, :where, :., :(<:), :(>:))
+end
+
+function pe_struct_field(expression)
+    value = expression
+    while value isa Expr && value.head == :const
+        length(value.args) == 1 || return nothing
+        value = only(value.args)
+    end
+
+    has_default = value isa Expr && value.head == :(=)
+    default = has_default ? last(value.args) : nothing
+    declaration = has_default ? first(value.args) : value
+    if declaration isa Symbol
+        return (
+            binding=declaration,
+            annotation=nothing,
+            has_default,
+            default,
+        )
+    elseif declaration isa Expr && declaration.head == :(::) &&
+            first(declaration.args) isa Symbol
+        return (
+            binding=first(declaration.args),
+            annotation=last(declaration.args),
+            has_default,
+            default,
+        )
+    end
+    return nothing
+end
+
+function _pe_collect_declarations!(
+    declarations::Vector{PETypeDeclaration},
+    expression,
+    relative_path::String,
+    line::Int,
+)
+    expression isa LineNumberNode && return expression.line
+    expression isa Expr || return line
+
+    if expression.head == :struct
+        mutable = expression.args[1]::Bool
+        name = pe_declaration_name(expression.args[2])
+        body = expression.args[3]
+        fields = body isa Expr && body.head == :block ?
+            count(value -> pe_struct_field(value) !== nothing,
+                body.args) : 0
+        if name !== nothing && pe_has_vocabulary(String(name))
+            push!(declarations, PETypeDeclaration(
+                relative_path,
+                String(name),
+                mutable ? "mutable_struct" : "struct",
+                mutable,
+                fields,
+                line,
+            ))
+        end
+    elseif expression.head in (:abstract, :primitive)
+        name = pe_declaration_name(first(expression.args))
+        if name !== nothing && pe_has_vocabulary(String(name))
+            push!(declarations, PETypeDeclaration(
+                relative_path,
+                String(name),
+                expression.head == :abstract ?
+                    "abstract_type" : "primitive_type",
+                false,
+                -1,
+                line,
+            ))
+        end
+    elseif expression.head == :macrocall &&
+            pe_type_name(first(expression.args)) === Symbol("@enum")
+        name = length(expression.args) >= 3 ?
+            pe_declaration_name(expression.args[3]) : nothing
+        if name !== nothing && pe_has_vocabulary(String(name))
+            push!(declarations, PETypeDeclaration(
+                relative_path,
+                String(name),
+                "enum",
+                false,
+                -1,
+                line,
+            ))
+        end
+    elseif expression.head == :const && length(expression.args) == 1
+        assignment = first(expression.args)
+        if assignment isa Expr && assignment.head == :(=)
+            name = first(assignment.args)
+            target = last(assignment.args)
+            if name isa Symbol && pe_has_vocabulary(String(name)) &&
+                    pe_is_type_alias_rhs(target)
+                push!(declarations, PETypeDeclaration(
+                    relative_path,
+                    String(name),
+                    "type_alias",
+                    false,
+                    -1,
+                    line,
+                ))
+            end
+        end
+    end
+
+    current_line = line
+    for argument in expression.args
+        current_line = _pe_collect_declarations!(
+            declarations, argument, relative_path, current_line)
+    end
+    return current_line
+end
+
+function pe_type_declarations(root::AbstractString)
+    declarations = PETypeDeclaration[]
+    for path in pe_source_paths(root)
+        relative_path = relpath(path, root)
+        expression = Meta.parseall(read(path, String); filename=path)
+        _pe_collect_declarations!(declarations, expression, relative_path, 1)
+    end
+    sort!(declarations; by=value -> (value.path, value.name))
+    return declarations
+end
+
+function pe_contains_any(expression)
+    expression === :Any && return true
+    expression isa QuoteNode && return false
+    expression isa Expr || return false
+    return any(pe_contains_any, expression.args)
+end
+
+function pe_is_memory_type(expression)
+    expression === :Memory && return true
+    expression isa Expr || return false
+    expression.head in (:curly, :.) || return false
+    return pe_type_name(expression) === :Memory
+end
+
+function pe_storage_type_contains_any(expression)
+    expression isa Expr && expression.head == :curly || return false
+    root = pe_type_name(first(expression.args))
+    root in PE_NONSTORAGE_SIGNATURE_ROOTS && return false
+    root in PE_STORAGE_TYPE_ROOTS || return false
+    return pe_contains_any(expression)
+end
+
+function pe_is_implicit_any_constructor(expression)
+    expression isa Expr && expression.head == :call || return false
+    callee = first(expression.args)
+    (callee isa Symbol ||
+        (callee isa Expr && callee.head == :.)) || return false
+    root = pe_type_name(callee)
+    positional_count = 0
+    first_positional = nothing
+    for argument in Iterators.drop(expression.args, 1)
+        argument isa Expr && argument.head == :parameters && continue
+        positional_count += 1
+        positional_count == 1 && (first_positional = argument)
+    end
+    root in PE_IMPLICIT_ANY_EMPTY_CONSTRUCTORS &&
+        return positional_count == 0
+    root === :Vector &&
+        return positional_count == 0 || first_positional === :undef
+    root === :Matrix && return first_positional === :undef
+    return false
+end
+
+function pe_expression_binding(expression)
+    expression isa Symbol && return String(expression)
+    expression isa Expr || return "<expression>"
+    if expression.head == :(::)
+        return pe_expression_binding(first(expression.args))
+    elseif expression.head in (:ref, :.)
+        return pe_expression_binding(first(expression.args))
+    elseif expression.head == :tuple
+        return "<destructured>"
+    end
+    return "<expression>"
+end
+
+function pe_function_name(signature)
+    signature isa Symbol && return String(signature)
+    signature isa Expr || return "<anonymous>"
+    if signature.head in (:where, :(::))
+        return pe_function_name(first(signature.args))
+    elseif signature.head == :call
+        name = first(signature.args)
+        symbol = pe_type_name(name)
+        return symbol === nothing ? string(name) : String(symbol)
+    end
+    return "<anonymous>"
+end
+
+function _pe_push_site!(
+    sites::Vector{PEDebtSite},
+    path::String,
+    category::String,
+    scope::String,
+    binding::String,
+    line::Int,
+)
+    push!(sites, PEDebtSite(path, category, scope, binding, line))
+    return nothing
+end
+
+function _pe_memory_type_sites!(
+    sites::Vector{PEDebtSite},
+    expression,
+    path::String,
+    category::String,
+    scope::String,
+    binding::String,
+    line::Int,
+)
+    expression === :Memory && begin
+        _pe_push_site!(sites, path, category, scope, binding, line)
+        return
+    end
+    expression isa Expr || return
+    if pe_is_memory_type(expression)
+        _pe_push_site!(sites, path, category, scope, binding, line)
+        for argument in Iterators.drop(expression.args, 1)
+            _pe_memory_type_sites!(sites, argument, path, category,
+                scope, binding, line)
+        end
+        return
+    end
+    for argument in expression.args
+        _pe_memory_type_sites!(sites, argument, path, category,
+            scope, binding, line)
+    end
+    return
+end
+
+function _pe_scan_signature!(
+    memory_sites::Vector{PEDebtSite},
+    any_sites::Vector{PEDebtSite},
+    signature,
+    path::String,
+    line::Int,
+)
+    function_name = pe_function_name(signature)
+    callable = signature
+    while callable isa Expr && callable.head == :where
+        for constraint in Iterators.drop(callable.args, 1)
+            _pe_memory_type_sites!(memory_sites, constraint, path,
+                "signature_type", function_name, "<constraint>", line)
+        end
+        callable = first(callable.args)
+    end
+    if callable isa Expr && callable.head == :(::)
+        return_type = last(callable.args)
+        _pe_memory_type_sites!(memory_sites, return_type, path,
+            "signature_type", function_name, "<return>", line)
+        if pe_storage_type_contains_any(return_type)
+            _pe_push_site!(any_sites, path, "return_erased_storage",
+                function_name, "<return>", line)
+        elseif occursin("prepare", lowercase(function_name)) &&
+                pe_contains_any(return_type)
+            _pe_push_site!(any_sites, path, "prepared_return_any",
+                function_name, "<return>", line)
+        end
+        callable = first(callable.args)
+    end
+    callable isa Expr && callable.head == :call || return
+    for argument in Iterators.drop(callable.args, 1)
+        argument isa Expr || continue
+        if argument.head == :parameters
+            for keyword in argument.args
+                _pe_scan_signature_argument!(memory_sites, any_sites,
+                    keyword, path, function_name, line)
+            end
+        else
+            _pe_scan_signature_argument!(memory_sites, any_sites,
+                argument, path, function_name, line)
+        end
+    end
+    return
+end
+
+function _pe_scan_signature_argument!(
+    memory_sites::Vector{PEDebtSite},
+    any_sites::Vector{PEDebtSite},
+    argument,
+    path::String,
+    function_name::String,
+    line::Int,
+)
+    value = argument isa Expr && argument.head in (:kw, :(=)) ?
+        first(argument.args) : argument
+    value isa Expr && value.head == :(... ) &&
+        (value = first(value.args))
+    value isa Expr && value.head == :(::) || return
+    binding = pe_expression_binding(first(value.args))
+    annotation = last(value.args)
+    _pe_memory_type_sites!(memory_sites, annotation, path,
+        "signature_type", function_name, binding, line)
+    if pe_storage_type_contains_any(annotation)
+        _pe_push_site!(any_sites, path, "signature_erased_storage",
+            function_name, binding, line)
+    end
+    return
+end
+
+function _pe_scan_struct_body!(
+    memory_sites::Vector{PEDebtSite},
+    any_sites::Vector{PEDebtSite},
+    body,
+    path::String,
+    type_name::String,
+    line::Int,
+)
+    body isa Expr && body.head == :block ||
+        return _pe_scan_expression!(memory_sites, any_sites, body,
+            path, line, type_name, "<expression>")
+    current_line = line
+    for field in body.args
+        if field isa LineNumberNode
+            current_line = field.line
+            continue
+        end
+        field_parts = pe_struct_field(field)
+        if field_parts !== nothing && field_parts.annotation !== nothing
+            binding = String(field_parts.binding)
+            annotation = field_parts.annotation
+            _pe_memory_type_sites!(memory_sites, annotation, path,
+                "field_type", type_name, binding, current_line)
+            if pe_contains_any(annotation)
+                _pe_push_site!(any_sites, path, "field_stored_any",
+                    type_name, binding, current_line)
+            end
+            if field_parts.has_default
+                current_line = _pe_scan_expression!(memory_sites,
+                    any_sites, field_parts.default, path, current_line,
+                    type_name, binding)
+            end
+        elseif field_parts !== nothing
+            binding = String(field_parts.binding)
+            _pe_push_site!(any_sites, path, "field_stored_any",
+                type_name, binding, current_line)
+            if field_parts.has_default
+                current_line = _pe_scan_expression!(memory_sites,
+                    any_sites, field_parts.default, path, current_line,
+                    type_name, binding)
+            end
+        else
+            current_line = _pe_scan_expression!(memory_sites, any_sites,
+                field, path, current_line, type_name, "<expression>")
+        end
+    end
+    return current_line
+end
+
+
+function _pe_scan_call_arguments!(
+    memory_sites::Vector{PEDebtSite},
+    any_sites::Vector{PEDebtSite},
+    expression::Expr,
+    path::String,
+    line::Int,
+    scope::String,
+)
+    current_line = line
+    for argument in Iterators.drop(expression.args, 1)
+        current_line = _pe_scan_expression!(memory_sites, any_sites,
+            argument, path, current_line, scope, "<argument>")
+    end
+    return current_line
+end
+
+function _pe_scan_expression!(
+    memory_sites::Vector{PEDebtSite},
+    any_sites::Vector{PEDebtSite},
+    expression,
+    path::String,
+    line::Int,
+    scope::String,
+    binding::String,
+)
+    expression isa LineNumberNode && return expression.line
+    expression isa Expr || return line
+
+    if expression.head == :struct
+        name = something(pe_declaration_name(expression.args[2]),
+            Symbol("<anonymous>"))
+        _pe_memory_type_sites!(memory_sites, expression.args[2], path,
+            "type_constraint", String(name), "<type-parameter>", line)
+        return _pe_scan_struct_body!(memory_sites, any_sites,
+            expression.args[3], path, String(name), line)
+    elseif expression.head in (:abstract, :primitive)
+        _pe_memory_type_sites!(memory_sites, first(expression.args), path,
+            "type_constraint", string(pe_declaration_name(
+                first(expression.args))), "<type-parameter>", line)
+        return line
+    elseif expression.head == :function
+        _pe_scan_signature!(memory_sites, any_sites,
+            expression.args[1], path, line)
+        length(expression.args) == 1 && return line
+        return _pe_scan_expression!(memory_sites, any_sites,
+            expression.args[2], path, line,
+            pe_function_name(expression.args[1]), "<expression>")
+    elseif expression.head == :(=) &&
+            (first(expression.args) isa Expr) &&
+            first(expression.args).head in (:call, :where, :(::))
+        _pe_scan_signature!(memory_sites, any_sites,
+            first(expression.args), path, line)
+        return _pe_scan_expression!(memory_sites, any_sites,
+            last(expression.args), path, line,
+            pe_function_name(first(expression.args)), "<expression>")
+    elseif expression.head == :(=)
+        destination = pe_expression_binding(first(expression.args))
+        current_line = _pe_scan_expression!(memory_sites, any_sites,
+            first(expression.args), path, line, scope, destination)
+        return _pe_scan_expression!(memory_sites, any_sites,
+            last(expression.args), path, current_line, scope, destination)
+    elseif expression.head == :call &&
+            pe_is_memory_type(first(expression.args))
+        _pe_push_site!(memory_sites, path, "constructor", scope,
+            binding, line)
+        pe_storage_type_contains_any(first(expression.args)) &&
+            _pe_push_site!(any_sites, path,
+                "erased_storage_constructor", scope, binding, line)
+        return _pe_scan_call_arguments!(memory_sites, any_sites,
+            expression, path, line, scope)
+    elseif expression.head == :call &&
+            pe_storage_type_contains_any(first(expression.args))
+        _pe_push_site!(any_sites, path, "erased_storage_constructor",
+            scope, binding, line)
+        return _pe_scan_call_arguments!(memory_sites, any_sites,
+            expression, path, line, scope)
+    elseif pe_is_implicit_any_constructor(expression)
+        _pe_push_site!(any_sites, path,
+            "implicit_any_storage_constructor", scope, binding, line)
+        return _pe_scan_call_arguments!(memory_sites, any_sites,
+            expression, path, line, scope)
+    elseif expression.head == :ref && !isempty(expression.args) &&
+            first(expression.args) === :Any
+        _pe_push_site!(any_sites, path, "any_array_literal", scope,
+            binding, line)
+    elseif expression.head == :vect && isempty(expression.args)
+        _pe_push_site!(any_sites, path, "implicit_any_array_literal",
+            scope, binding, line)
+    elseif expression.head == :(::)
+        annotation = last(expression.args)
+        _pe_memory_type_sites!(memory_sites, annotation, path,
+            "local_type", scope,
+            pe_expression_binding(first(expression.args)), line)
+        if pe_storage_type_contains_any(annotation)
+            _pe_push_site!(any_sites, path, "local_erased_storage",
+                scope, pe_expression_binding(first(expression.args)), line)
+        end
+        return line
+    elseif pe_is_memory_type(expression)
+        _pe_push_site!(memory_sites, path, "type_reference", scope,
+            binding, line)
+        return line
+    end
+
+    current_line = line
+    for argument in expression.args
+        current_line = _pe_scan_expression!(memory_sites, any_sites,
+            argument, path, current_line, scope, binding)
+    end
+    return current_line
+end
+
+function pe_debt_sites(root::AbstractString)
+    memory_sites = PEDebtSite[]
+    any_sites = PEDebtSite[]
+    for path in pe_source_paths(root)
+        relative_path = relpath(path, root)
+        expression = Meta.parseall(read(path, String); filename=path)
+        _pe_scan_expression!(memory_sites, any_sites, expression,
+            relative_path, 1, "<top-level>", "<expression>")
+    end
+    order(site) = (site.path, site.category, site.scope,
+        site.binding, site.line)
+    sort!(memory_sites; by=order)
+    sort!(any_sites; by=order)
+    return (memory=memory_sites, stored_any=any_sites)
+end
+
+function pe_debt_counts(sites)
+    counts = Dict{Tuple{String,String,String,String},Int}()
+    for site in sites
+        key = (site.path, site.category, site.scope, site.binding)
+        counts[key] = get(counts, key, 0) + 1
+    end
+    return counts
+end

--- a/test/prepared_execution_contract_helpers.jl
+++ b/test/prepared_execution_contract_helpers.jl
@@ -82,6 +82,9 @@ function pe_source_paths(root::AbstractString)
     return sort!(paths)
 end
 
+pe_normalize_repository_path(path::AbstractString) =
+    replace(String(path), '\\' => '/')
+
 function pe_camel_tokens(name::AbstractString)
     tokens = String[]
     for component in split(strip(name, '_'), '_')
@@ -238,7 +241,7 @@ end
 function pe_type_declarations(root::AbstractString)
     declarations = PETypeDeclaration[]
     for path in pe_source_paths(root)
-        relative_path = relpath(path, root)
+        relative_path = pe_normalize_repository_path(relpath(path, root))
         expression = Meta.parseall(read(path, String); filename=path)
         _pe_collect_declarations!(declarations, expression, relative_path, 1)
     end
@@ -592,7 +595,7 @@ function pe_debt_sites(root::AbstractString)
     memory_sites = PEDebtSite[]
     any_sites = PEDebtSite[]
     for path in pe_source_paths(root)
-        relative_path = relpath(path, root)
+        relative_path = pe_normalize_repository_path(relpath(path, root))
         expression = Meta.parseall(read(path, String); filename=path)
         _pe_scan_expression!(memory_sites, any_sites, expression,
             relative_path, 1, "<top-level>", "<expression>")

--- a/test/test_selection.jl
+++ b/test/test_selection.jl
@@ -38,6 +38,11 @@ const TEST_SUITE_SPECS = (
         fixtures=("ka_cpu_style_fixture.jl",)),
     TestSuiteSpec("tomography", "tomography.jl"),
     TestSuiteSpec("quality", "testsets/quality.jl"),
+    TestSuiteSpec(
+        "prepared-execution-contracts",
+        "testsets/prepared_execution_contracts.jl";
+        fixtures=("prepared_execution_contract_helpers.jl",),
+    ),
     TestSuiteSpec("namespace-authority",
         "testsets/namespace_authority.jl"),
     TestSuiteSpec("core-optics", "testsets/core_optics.jl"),
@@ -418,6 +423,7 @@ const TEST_CI_SHARD_SPECS = (
         "ka-cpu",
         "tomography",
         "quality",
+        "prepared-execution-contracts",
         "namespace-authority",
         "core-optics",
         "direct-science",

--- a/test/testsets/prepared_execution_contracts.jl
+++ b/test/testsets/prepared_execution_contracts.jl
@@ -2,6 +2,11 @@ const PE_CONTRACT_ROOT = joinpath(dirname(@__DIR__), "contracts")
 const PE_REPOSITORY_ROOT = dirname(dirname(@__DIR__))
 
 @testset "PE-00 source scanner semantics" begin
+    @test pe_normalize_repository_path(raw"src\plant\preparation.jl") ==
+        "src/plant/preparation.jl"
+    @test pe_normalize_repository_path("src/plant/preparation.jl") ==
+        "src/plant/preparation.jl"
+
     function scan_snippet(source)
         expression = Meta.parseall(source; filename="synthetic.jl")
         memory_sites = PEDebtSite[]

--- a/test/testsets/prepared_execution_contracts.jl
+++ b/test/testsets/prepared_execution_contracts.jl
@@ -1,0 +1,312 @@
+const PE_CONTRACT_ROOT = joinpath(dirname(@__DIR__), "contracts")
+const PE_REPOSITORY_ROOT = dirname(dirname(@__DIR__))
+
+@testset "PE-00 source scanner semantics" begin
+    function scan_snippet(source)
+        expression = Meta.parseall(source; filename="synthetic.jl")
+        memory_sites = PEDebtSite[]
+        any_sites = PEDebtSite[]
+        _pe_scan_expression!(memory_sites, any_sites, expression,
+            "synthetic.jl", 1, "<top-level>", "<expression>")
+        return (memory=memory_sites, stored_any=any_sites)
+    end
+
+    permitted = scan_snippet("""
+        wildcard(::Any) = nothing
+        bounded(x::Tuple{P,Vararg{Any,N}}) where {P,N} = x
+        unconstrained(x::T) where {T<:Any} = x
+        invoke(wildcard, Tuple{Any}, 1)
+    """)
+    @test isempty(permitted.memory)
+    @test isempty(permitted.stored_any)
+
+    prohibited = scan_snippet("""
+        struct BadOwner
+            untyped
+            scalar::Any
+            values::Vector{Any}
+            fixed::Memory{Any}
+            qualified::Base.Memory{Int}
+            erased_fixed::FixedSizeArray{Any}
+            const qualified_const::Base.Memory{Int}
+            const erased_const::Vector{Any} = Any[]
+        end
+        function prepare_bad(values::Vector{Any})::Any
+            scratch = Any[]
+            fixed = Memory{Any}(undef, 1)
+            qualified = Base.Memory{Int}(undef, 1)
+            erased_fixed = FixedSizeArray{Any}(undef, 1)
+            mapped = Dict{String,Any}()
+            return values, scratch, fixed, qualified, erased_fixed, mapped
+        end
+        function return_bad()::Vector{Any}
+            implicit_array = []
+            implicit_dict = Dict()
+            implicit_id_dict = IdDict()
+            implicit_weak_dict = WeakKeyDict()
+            implicit_set = Set()
+            implicit_vector = Vector()
+            implicit_sized_vector = Vector(undef, 1)
+            implicit_matrix = Matrix(undef, 1, 1)
+            return implicit_array, implicit_dict, implicit_id_dict,
+                implicit_weak_dict, implicit_set, implicit_vector,
+                implicit_sized_vector, implicit_matrix
+        end
+    """)
+    @test count(site -> site.category == "field_stored_any",
+        prohibited.stored_any) == 6
+    @test count(site -> site.category == "signature_erased_storage",
+        prohibited.stored_any) == 1
+    @test count(site -> site.category == "prepared_return_any",
+        prohibited.stored_any) == 1
+    @test count(site -> site.category == "any_array_literal",
+        prohibited.stored_any) == 2
+    @test count(site -> site.category == "erased_storage_constructor",
+        prohibited.stored_any) == 3
+    @test count(site -> site.category ==
+            "implicit_any_storage_constructor",
+        prohibited.stored_any) == 7
+    @test count(site -> site.category == "implicit_any_array_literal",
+        prohibited.stored_any) == 1
+    @test count(site -> site.category == "return_erased_storage",
+        prohibited.stored_any) == 1
+    @test count(site -> site.category == "field_type",
+        prohibited.memory) == 3
+    @test count(site -> site.category == "constructor",
+        prohibited.memory) == 2
+end
+
+@testset "PE-00 prepared execution contract" begin
+    contract_path = joinpath(
+        PE_CONTRACT_ROOT,
+        "prepared_execution_ownership.toml",
+    )
+    @test isfile(contract_path)
+    contract = TOML.parsefile(contract_path)
+    @test contract["schema_version"] == 1
+    @test contract["name"] == "prepared_execution_ownership"
+    @test contract["status"] == "characterized_baseline"
+
+    inventory = contract["type_inventory"]
+    @test Set(String.(inventory["vocabulary_tokens"])) ==
+        PE_VOCABULARY
+    columns = String.(inventory["columns"])
+    @test columns == [
+        "name",
+        "declaration",
+        "field_count",
+        "current_role",
+        "target_roles",
+        "mutable",
+        "persistent_state",
+        "product_visibility",
+        "exact_binding",
+        "backend_relevance",
+        "cpu_hot_path",
+        "migration_gate",
+    ]
+    @test !isempty(inventory["target_roles_semantics"])
+
+    expected = Dict{Tuple{String,String},Tuple{String,Bool,Int}}()
+    mixed_target_count = 0
+    allowed_current = Set(String.(inventory["allowed_current_roles"]))
+    allowed_target = Set(String.(inventory["allowed_target_roles"]))
+    allowed_visibility = Set(String.(inventory["allowed_product_visibility"]))
+    allowed_backend = Set(String.(inventory["allowed_backend_relevance"]))
+    allowed_gates = Set(String.(inventory["allowed_migration_gates"]))
+    @test issorted(String(file["path"]) for file in inventory["files"])
+    for file in inventory["files"]
+        path = String(file["path"])
+        @test isfile(joinpath(PE_REPOSITORY_ROOT, path))
+        @test !isempty(file["owner"])
+        @test issorted(String(row[1]) for row in file["entries"])
+        for row in file["entries"]
+            @test length(row) == length(columns)
+            values = Dict(columns .=> row)
+            key = (path, String(values["name"]))
+            @test !haskey(expected, key)
+            @test values["declaration"] in
+                ("struct", "mutable_struct", "abstract_type",
+                    "primitive_type", "type_alias", "enum")
+            @test values["field_count"] isa Integer
+            @test values["current_role"] in allowed_current
+            @test values["target_roles"] isa Vector
+            @test !isempty(values["target_roles"])
+            @test all(in(allowed_target), values["target_roles"])
+            @test length(unique(values["target_roles"])) ==
+                length(values["target_roles"])
+            mixed_target_count += length(values["target_roles"]) > 1
+            @test values["mutable"] isa Bool
+            @test values["persistent_state"] isa Bool
+            @test values["product_visibility"] in allowed_visibility
+            @test values["exact_binding"] isa Bool
+            @test values["backend_relevance"] in allowed_backend
+            @test values["cpu_hot_path"] isa Bool
+            @test values["migration_gate"] in allowed_gates
+            values["persistent_state"] &&
+                @test "state" in values["target_roles"]
+            values["product_visibility"] == "caller_visible" &&
+                @test "product" in values["target_roles"]
+            values["target_roles"] == ["binding_token"] && begin
+                @test values["field_count"] == 0
+                @test values["exact_binding"]
+            end
+            "strategy" in values["target_roles"] &&
+                @test values["field_count"] == 0
+            values["current_role"] == "plan" &&
+                    values["field_count"] == 0 &&
+                @test !isdisjoint(values["target_roles"],
+                    ("strategy", "binding_token"))
+            expected[key] = (
+                String(values["declaration"]),
+                values["mutable"],
+                values["field_count"],
+            )
+        end
+    end
+    @test mixed_target_count == inventory["baseline_mixed_type_count"]
+    @test length(expected) == inventory["baseline_type_count"]
+
+    observed = Dict(
+        (declaration.path, declaration.name) =>
+            (declaration.declaration, declaration.mutable,
+                declaration.field_count)
+        for declaration in pe_type_declarations(PE_REPOSITORY_ROOT)
+    )
+    @test expected == observed
+
+    debt = pe_debt_sites(PE_REPOSITORY_ROOT)
+    for (section_name, sites) in (
+        "direct_memory" => debt.memory,
+        "stored_any" => debt.stored_any,
+    )
+        section = contract[section_name]
+        @test section["policy"] == "ratchet"
+        site_columns = String.(section["columns"])
+        baseline = Dict{Tuple{String,String,String,String},Int}()
+        for file in section["files"]
+            path = String(file["path"])
+            @test isfile(joinpath(PE_REPOSITORY_ROOT, path))
+            @test !isempty(file["owner"])
+            for row in file["entries"]
+                @test length(row) == length(site_columns)
+                values = Dict(site_columns .=> row)
+                key = (
+                    path,
+                    String(values["category"]),
+                    String(values["scope"]),
+                    String(values["binding"]),
+                )
+                @test !haskey(baseline, key)
+                @test values["baseline_line"] > 0
+                @test values["count"] > 0
+                @test values["hot_path"] isa Bool
+                @test !isempty(values["replacement"])
+                section_name == "direct_memory" &&
+                    @test values["backend_relevance"] ==
+                        "host_ownership_storage"
+                baseline[key] = values["count"]
+            end
+        end
+        observed_counts = pe_debt_counts(sites)
+        observed_keys = Set(keys(observed_counts))
+        baseline_keys = Set(keys(baseline))
+        @test isempty(setdiff(observed_keys, baseline_keys))
+        @test all(observed_counts[key] <= baseline[key]
+            for key in intersect(observed_keys, baseline_keys))
+        @test sum(values(observed_counts)) <= section["baseline_total"]
+        @test section["baseline_total"] == sum(values(baseline))
+    end
+
+    evidence = contract["evidence_index"]
+    @test Set(String.(evidence["classes"])) == Set((
+        "numerical",
+        "inference",
+        "allocation",
+        "storage",
+        "package_load",
+        "cpu",
+        "cuda",
+        "amdgpu",
+    ))
+    for entry in evidence["entries"]
+        @test entry["class"] in evidence["classes"]
+        @test isfile(joinpath(PE_REPOSITORY_ROOT, entry["path"]))
+        @test !isempty(entry["claim_limit"])
+    end
+
+    hil = contract["adaptive_optics_hil"]
+    @test length(hil["source_revision"]) == 40
+    hil_inventory_path = joinpath(
+        PE_REPOSITORY_ROOT, hil["import_inventory"])
+    @test isfile(hil_inventory_path)
+    hil_inventory = TOML.parsefile(hil_inventory_path)
+    @test hil_inventory["schema_version"] == 1
+    @test hil_inventory["status"] == "frozen_source_snapshot"
+    @test hil_inventory["repository"] == hil["repository"]
+    @test hil_inventory["source_revision"] == hil["source_revision"]
+    @test hil_inventory["adaptive_optics_sim_pin"] ==
+        hil["adaptive_optics_sim_pin"]
+    @test all(hash -> length(hash) == 64, (
+        hil_inventory["project_files"]["package_sha256"],
+        hil_inventory["project_files"]["benchmarks_sha256"],
+    ))
+    @test Set((
+        "PreparedPlantEventLoop",
+        "PlantEventLoopState",
+        "PlantEventLoopWorkspace",
+    )) ⊆ Set(String.(hil["affected_owner_types"]))
+    affected = Set(String.(hil["affected_owner_types"]))
+    @test affected == Set(String.(
+        hil_inventory["ownership"]["affected_symbols"]))
+    @test !isempty(hil["construction_assumptions"])
+    @test hil["construction_assumptions"] ==
+        hil_inventory["ownership"]["construction_assumptions"]
+    referenced = Set{String}()
+    for entry in hil_inventory["reference_files"]
+        @test entry["scope"] in hil_inventory["scope"]
+        @test startswith(entry["path"], entry["scope"] * "/")
+        @test length(entry["sha256"]) == 64
+        @test !isempty(entry["symbols"])
+        union!(referenced, String.(entry["symbols"]))
+    end
+    @test referenced == affected
+    hil_memory = hil_inventory["direct_memory"]
+    @test hil_memory["migration_gate"] == "PE-08"
+    memory_files = Dict(String(row[1]) => Int(row[2])
+        for row in hil_memory["files"])
+    @test length(memory_files) == length(hil_memory["files"])
+    memory_count(prefix) = sum((count for (path, count) in memory_files
+        if startswith(path, prefix)); init=0)
+    @test hil_memory["source_total"] == memory_count("src/")
+    @test hil_memory["test_total"] == memory_count("test/")
+    @test hil_memory["benchmarks_total"] == memory_count("benchmarks/")
+
+    fixed = contract["fixed_size_arrays"]
+    @test fixed["core_dependency"] === false
+    @test fixed["characterized_version"] == "1.3.0"
+    @test isfile(joinpath(PE_REPOSITORY_ROOT, fixed["project"]))
+    @test isfile(joinpath(PE_REPOSITORY_ROOT, fixed["contract"]))
+    @test isfile(joinpath(PE_REPOSITORY_ROOT, fixed["artifact"]))
+    fixed_artifact = TOML.parsefile(joinpath(
+        PE_REPOSITORY_ROOT, fixed["artifact"]))
+    @test fixed_artifact["correctness_passed"]
+    @test fixed_artifact["fixed_size_arrays_version"] ==
+        fixed["characterized_version"]
+    @test all(iszero, values(
+        fixed_artifact["warmed_allocated_bytes"]))
+    @test all(identity, values(fixed_artifact["inference"]))
+    @test fixed_artifact["shape_contract"][
+        "runtime_vector_lengths_share_type"]
+    @test fixed_artifact["shape_contract"][
+        "runtime_matrix_shapes_share_type"]
+    @test fixed_artifact["shape_contract"]["resize_rejected"]
+    @test fixed_artifact["shape_contract"]["push_rejected"]
+    @test fixed_artifact["element_type_contract"][
+        "any_is_constructible"]
+    @test fixed_artifact["element_type_contract"][
+        "concrete_is_accepted"]
+    @test fixed_artifact["element_type_contract"]["any_is_rejected"]
+    @test !fixed_artifact["storage_comparison"][
+        "dependency_backing_inspected"]
+end

--- a/test/testsets/prepared_execution_contracts.jl
+++ b/test/testsets/prepared_execution_contracts.jl
@@ -288,11 +288,30 @@ end
     @test isfile(joinpath(PE_REPOSITORY_ROOT, fixed["project"]))
     @test isfile(joinpath(PE_REPOSITORY_ROOT, fixed["contract"]))
     @test isfile(joinpath(PE_REPOSITORY_ROOT, fixed["artifact"]))
+    fixed_contract = TOML.parsefile(joinpath(
+        PE_REPOSITORY_ROOT, fixed["contract"]))
     fixed_artifact = TOML.parsefile(joinpath(
         PE_REPOSITORY_ROOT, fixed["artifact"]))
     @test fixed_artifact["correctness_passed"]
+    @test !fixed_artifact["repository_dirty"]
+    @test length(fixed_artifact["repository_head"]) == 40
+    @test fixed_artifact["julia_version"] ==
+        fixed_contract["julia_version"]
+    @test fixed_artifact["fresh_process_runs"] ==
+        fixed_contract["fresh_process_runs"]
     @test fixed_artifact["fixed_size_arrays_version"] ==
         fixed["characterized_version"]
+    @test fixed_artifact["julia_threads"] == 1
+    @test fixed_artifact["logical_cpu_threads"] > 0
+    for key in (
+        "kernel",
+        "architecture",
+        "cpu_target",
+        "cpu_model",
+        "julia_cpu_target_env",
+    )
+        @test !isempty(fixed_artifact[key])
+    end
     @test all(iszero, values(
         fixed_artifact["warmed_allocated_bytes"]))
     @test all(identity, values(fixed_artifact["inference"]))

--- a/test/testsets/quality.jl
+++ b/test/testsets/quality.jl
@@ -411,12 +411,17 @@ end
             "plant_device_model_matrix_fixtures.jl",
         ),
         joinpath(dirname(@__DIR__), "plant_test_fixtures.jl"),
+        joinpath(
+            dirname(@__DIR__),
+            "prepared_execution_contract_helpers.jl",
+        ),
         joinpath(dirname(@__DIR__), "wfs_stage_contract_fixtures.jl"),
     ]))
     fixture_users = Tuple(spec.name for spec in TEST_SUITE_SPECS
         if !isempty(spec.fixtures))
     @test fixture_users == (
         "ka-cpu",
+        "prepared-execution-contracts",
         "direct-imaging-batch",
         "atmosphere-direction-batch",
         "plant-device-batching",


### PR DESCRIPTION
Closes #227
Tracker: #225
Next sequenced gate: #229

## What changed

- Added an executable ownership inventory for all 381 source and extension declarations participating in the definition/params/plan/prepared/state/workspace/product/strategy vocabulary.
- Classified current and target responsibilities, including 32 mixed-responsibility owners that later PE gates must decompose.
- Added AST-aware ratchets for 344 direct Memory sites across 26 files and 25 stored or builder Any sites across eight files.
- Added negative and permitted-wildcard scanner tests, including const fields, qualified Memory, type-erased return storage, implicit boxed builders, and repository-normalized paths on Windows.
- Characterized FixedSizeArrays 1.3.0 in an isolated Julia 1.12 environment without adding it to the root package.
- Recorded architecture, CPU, Julia thread, and clean-repository provenance with the latency and storage evidence.
- Pinned the current AdaptiveOpticsHIL ownership/import snapshot and indexed existing numerical, inference, allocation, CPU, CUDA, and AMDGPU evidence.
- Added a focused prepared-execution-contracts selector to the ci-foundations shard.

## Why

The prepared-execution refactor needs a mechanically enforced baseline before plan, state, workspace, product, and exact-binding owners change. The previous prose inventory understated stored Any debt and could not detect ownership drift.

## Impact

This PR changes no package or extension runtime implementation, public API, numerical algorithm, detector/WFS behavior, or hardware support claim. FixedSizeArrays remains an isolated benchmark dependency, and its internal backing representation is neither inspected nor exposed.

## Local validation

- julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(test_args=["prepared-execution-contracts","quality"])'
  - Aqua: 11/11
  - scanner semantics: 14/14
  - prepared-execution contract: 9,089/9,089
- julia --startup-file=no --history-file=no --threads=1 --project=benchmarks/fixed_size_arrays benchmarks/benchmark_fixed_size_arrays.jl
  - FixedSizeArrays 1.3.0
  - warmed indexing, iteration, and copyto!: 0 Julia heap bytes
  - concrete inference checks pass
  - different runtime vector lengths and matrix shapes share their corresponding concrete types
  - resize! and push! are rejected
  - architecture, CPU, Julia-thread, and clean-head provenance recorded
- git diff --check

The final characterization artifact was rerun from clean commit 22b4b73f3a45e3c4a22e2283cd2ae19da1432f2c. Absolute timing observations are descriptive, not performance thresholds or hardware claims.

## Review

A repository-consistency review found and corrected the missing host context in the initial latency artifact. CI then exposed native Windows path separators in the contract scanner; paths are now normalized at the scanner boundary and covered by an explicit regression test. No actionable findings remain. The large ownership TOML is the maintained machine-readable baseline; the hand-written scanner and test harness remain bounded and selectively runnable.