### PR TITLE
PE-01: establish domain-owned prepared-execution interfaces

### DIFF
--- a/src/backends/arrays.jl
+++ b/src/backends/arrays.jl
@@ -33,11 +33,19 @@ end
 #
 # Prepared single-owner execution contexts
 #
-# These contexts are intentionally internal. They let one prepared Plant
-# device-batch owner retain an exact backend stream without making stream
-# objects, task policy, or accelerator packages part of core's public API.
-# Optional backend extensions provide accelerator-specific implementations.
-#
+"""
+    _AbstractPreparedDeviceExecutionContext
+
+Internal extension interface for one prepared owner's exact compute-device and
+stream context. Implementations define
+`_prepared_device_execution_compute_device`,
+`_with_prepared_device_execution_context`, and
+`_synchronize_prepared_device_execution_context!`. Context entry must restore
+the caller's prior device and stream after normal return or failure. One
+context is externally serialized; nested entry may be supported, but concurrent
+ownership is not promised. Unsupported devices fail with a structured
+`ComputeDeviceError` or `InvalidConfiguration` during preparation.
+"""
 abstract type _AbstractPreparedDeviceExecutionContext end
 
 execution_style(A::AbstractArray) = execution_style(KernelAbstractions.get_backend(A))

--- a/src/calibration/interaction_matrix.jl
+++ b/src/calibration/interaction_matrix.jl
@@ -41,6 +41,19 @@ end
     return similar(ref, T, n_rows, n_cols)
 end
 
+"""
+    AbstractCalibrationCommandPlan
+
+Internal run-immutable interface for interaction-matrix command sequences.
+Implementations define `calibration_command_count` and
+`stage_calibration_command!`. Staging overwrites and returns caller-owned
+coefficient storage; it must not retain that destination. A plan may be reused
+concurrently only when its command data are not mutated and every invocation
+has distinct DM, WFS, pupil, and destination owners. Validation rejects shape,
+command-count, and output numeric-type incompatibilities before calibration
+mutation. Command storage must not alias the destination coefficients, and the
+two storage backends must support the staged copy and scaling operations.
+"""
 abstract type AbstractCalibrationCommandPlan end
 
 struct ActuatorCalibrationCommands <: AbstractCalibrationCommandPlan
@@ -87,6 +100,9 @@ function validate_calibration_commands(dm::DeformableMirror,
         throw(DimensionMismatchError("command matrix row count must match DM coefficients"))
     size(commands, 2) > 0 ||
         throw(InvalidConfiguration("interaction matrix requires at least one command mode"))
+    Base.mightalias(commands, dm.state.coefs) && throw(
+        InvalidConfiguration(
+            "calibration commands must not alias DM coefficient storage"))
     return MatrixCalibrationCommands(commands)
 end
 

--- a/src/optics/direct_imaging.jl
+++ b/src/optics/direct_imaging.jl
@@ -29,14 +29,12 @@ function apply_centering_phase!(style::AcceleratorStyle,
     return field
 end
 
-abstract type AbstractDirectImagingInputPlan end
-
 struct PreparedPupilImagingInput{
     F<:PupilFieldFormationPlan,
     M<:OpticalPlaneMetadata,
     A<:AbstractMatrix,
     O<:AbstractMatrix,
-} <: AbstractDirectImagingInputPlan
+}
     formation::F
     metadata::M
     amplitude::A
@@ -46,7 +44,7 @@ end
 struct PreparedFieldImagingInput{
     M<:OpticalPlaneMetadata,
     A<:AbstractMatrix,
-} <: AbstractDirectImagingInputPlan
+}
     metadata::M
     values::A
 end
@@ -61,7 +59,7 @@ periodic off-axis model; subpixel interpolation and finite-field loss require a
 different prepared mapping.
 """
 struct DirectImagingPlan{
-    I<:AbstractDirectImagingInputPlan,
+    I<:Union{PreparedPupilImagingInput,PreparedFieldImagingInput},
     FM<:OpticalPlaneMetadata,
     FA<:AbstractMatrix,
     OM<:OpticalPlaneMetadata,
@@ -259,7 +257,8 @@ function _direct_imaging_shift(output::IntensityMap, src::AbstractSource)
     end
 end
 
-function _prepare_direct_imaging(input_plan::AbstractDirectImagingInputPlan,
+function _prepare_direct_imaging(
+    input_plan::Union{PreparedPupilImagingInput,PreparedFieldImagingInput},
     field::ElectricField, output::IntensityMap,
     propagation::FraunhoferPropagation, src::AbstractSource)
     require_same_plane_grid(output.metadata, propagation.output_metadata;
@@ -519,14 +518,6 @@ function _require_exact_direct_imaging_input_target(
     validate_plane_storage(input.metadata, input.values;
         label="direct-imaging planned field")
     return input
-end
-
-function _require_exact_direct_imaging_input_target(
-    input::AbstractDirectImagingInputPlan,
-    ::AbstractComputeDevice,
-)
-    throw(InvalidConfiguration(
-        "no exact-target validator is defined for direct-imaging input plan $(typeof(input))"))
 end
 
 function _require_exact_direct_imaging_target(

--- a/src/plant/acquisition_lifecycles.jl
+++ b/src/plant/acquisition_lifecycles.jl
@@ -7,7 +7,18 @@ readout.
 """
 abstract type AbstractAcquisitionLifecycleDefinition end
 
-"""Common prepared boundary for one scheduled acquisition lifecycle."""
+"""
+    AbstractPreparedAcquisitionLifecycle
+
+Qualified-public prepared-owner interface for one scheduled acquisition.
+Implementations provide `begin_exposure!`, `complete_readout!`, exact-target
+validation through `_require_exact_acquisition_lifecycle_target`, and
+`structural_resource_fact` reporting. A prepared lifecycle binds one exact
+definition and product/resource owner; its matching mutable state is
+single-writer and non-reentrant. Every transition rejects a foreign binding or
+invalid transition with a structured Plant or detector-acquisition error before
+mutation. Independent prepared/state pairs may execute independently.
+"""
 abstract type AbstractPreparedAcquisitionLifecycle end
 
 """Common mutable single-writer state boundary for an acquisition lifecycle."""

--- a/src/plant/detector_acquisition_events.jl
+++ b/src/plant/detector_acquisition_events.jl
@@ -2,6 +2,16 @@ const _DETECTOR_ACQUISITION_EVENT_COMPONENT = :detector_acquisition_events
 
 abstract type AbstractDetectorAcquisitionLifecycleDefinition <:
     AbstractAcquisitionLifecycleDefinition end
+"""
+    AbstractPreparedDetectorAcquisitionLifecycle
+
+Prepared detector-backed subprotocol of `AbstractPreparedAcquisitionLifecycle`.
+Global-shutter, rolling-shutter, and frame-transfer implementations bind one
+exact detector, acquisition plan, readout product owner, and timing definition.
+Their matching state is single-writer and non-reentrant; invalid timing, mode,
+transition order, target, or state binding raises `DetectorAcquisitionError`
+before detector or lifecycle-state mutation.
+"""
 abstract type AbstractPreparedDetectorAcquisitionLifecycle <:
     AbstractPreparedAcquisitionLifecycle end
 abstract type AbstractDetectorAcquisitionLifecycleState <:

--- a/src/plant/effective_command_routes.jl
+++ b/src/plant/effective_command_routes.jl
@@ -7,6 +7,21 @@
 # cross-domain arrays acquire one dedicated typed handoff slot.
 #
 
+"""
+Internal prepared-owner interface for direct and remote effective-command
+publication. Implementations define
+`_prepare_effective_command_publication_route_state`,
+`_prepare_effective_command_publication_route!`,
+`_stage_effective_command_publication_route!`,
+`_reclaim_effective_command_publication_route!`,
+`_commit_effective_command_publication_route!`, and
+`_abandon_effective_command_publication_route!`. One route binds an exact
+authority, endpoint, destination, optic, and device context; remote routes
+additionally bind one handoff contract. Matching state is externally serialized
+and non-reentrant. Foreign bindings and reported transfer failures raise
+structured Plant errors before publication commit. An uncertain provider
+failure preserves fail-stop route ownership and may rethrow the provider error.
+"""
 abstract type _PreparedEffectiveCommandPublicationRoute end
 
 # Unlike the metadata-oriented `_FixedPlantRegistry`, this execution registry

--- a/src/plant/path_input_publications.jl
+++ b/src/plant/path_input_publications.jl
@@ -100,8 +100,17 @@ end
 """
 Prepared single-writer route for one exact target-local pupil-OPD input.
 
-Concrete direct and remote routes implement the lifecycle. Core creates no
-task, queue, wait strategy, event-loop integration, or scheduling policy.
+Concrete direct and remote routes implement
+`prepare_pupil_opd_publication_output`,
+`materialize_pupil_opd_publication!`, `submit_pupil_opd_publication!`,
+`try_complete_pupil_opd_publication!`, `apply_pupil_opd_publication!`, and
+`reclaim_pupil_opd_publication!`. One route binds its exact atmosphere
+authority, path, target-local pupil, materialization, phase, and optional
+handoff. It is externally serialized and retains an active publication until
+apply and reclaim. Preparation defects raise `PlantPreparationError`;
+lifecycle methods return typed status values and retain fail-stop ownership
+after uncertain transfer. Core creates no task, queue, wait strategy,
+event-loop integration, or scheduling policy.
 """
 abstract type PreparedPupilOPDPublicationRoute end
 

--- a/src/plant/reduced_order.jl
+++ b/src/plant/reduced_order.jl
@@ -534,18 +534,16 @@ function execute_acquisition_provider!(
         "linear reduced-order acquisition requires a prepared event loop with effective command state")
 end
 
-abstract type _PreparedReducedOrderEventResponse end
-
 struct _PreparedScalarReducedOrderEventResponse{
     R<:PreparedReducedOrderCommandResponse,
-} <: _PreparedReducedOrderEventResponse
+}
     response::R
     endpoint_slot::UInt32
 end
 
 struct _PreparedArrayReducedOrderEventResponse{
     R<:PreparedReducedOrderCommandResponse,
-} <: _PreparedReducedOrderEventResponse
+}
     response::R
     endpoint_slot::UInt32
 end

--- a/src/wfs/curvature/stages.jl
+++ b/src/wfs/curvature/stages.jl
@@ -154,18 +154,14 @@ struct CurvatureCalibrationBinding{T<:AbstractFloat,R,A}
     valid_support::A
 end
 
-abstract type AbstractPreparedCurvatureObservationMapping end
-
-struct CurvatureImagePairMapping{P,M} <:
-    AbstractPreparedCurvatureObservationMapping
+struct CurvatureImagePairMapping{P,M}
     plus::P
     minus::M
     plus_reduction::Int
     minus_reduction::Int
 end
 
-struct CurvatureChannelPairMapping{C} <:
-    AbstractPreparedCurvatureObservationMapping
+struct CurvatureChannelPairMapping{C}
     channels::C
 end
 

--- a/src/wfs/focal_plane_modulation.jl
+++ b/src/wfs/focal_plane_modulation.jl
@@ -139,9 +139,17 @@ end
 @inline photon_irradiance(source::FourPupilSpectralComponent) =
     source.photon_rate_m2_s
 
-# LGS image formation is prepared at the optical-stage boundary. These values
-# own only immutable execution data; the front-end propagation workspace
-# remains the single writer of FFT and scratch storage.
+"""
+    AbstractPreparedFourPupilLGS
+
+Internal prepared interface for four-pupil LGS image formation. Implementations
+define `apply_prepared_four_pupil_lgs!` and
+`_require_exact_prepared_four_pupil_lgs_target`. They own only run-immutable
+execution data. Intensity products and FFT scratch remain distinct,
+caller-owned, single-writer storage on the exact prepared target. A prepared
+value is reentrant only across distinct workspaces. Preparation and target
+validation raise `WFSPreparationError` before optical-product mutation.
+"""
 abstract type AbstractPreparedFourPupilLGS end
 
 struct NoPreparedFourPupilLGS <: AbstractPreparedFourPupilLGS end

--- a/test/backend_execution_context_conformance.jl
+++ b/test/backend_execution_context_conformance.jl
@@ -1,0 +1,36 @@
+function assert_prepared_device_execution_context_conformance(
+    context::C,
+    target::D,
+    observe::F,
+    expected_active::O,
+) where {
+    C<:Backends._AbstractPreparedDeviceExecutionContext,
+    D<:Backends.AbstractComputeDevice,
+    F,
+    O,
+}
+    @test @inferred(
+        Backends._prepared_device_execution_compute_device(context)) ==
+        target
+    caller_context = observe()
+    active_context =
+        Backends._with_prepared_device_execution_context(observe, context)
+    @test active_context == expected_active
+    @test observe() == caller_context
+
+    injected = ErrorException("injected prepared-context failure")
+    caught = try
+        Backends._with_prepared_device_execution_context(context) do
+            throw(injected)
+        end
+        nothing
+    catch error
+        error
+    end
+    @test caught === injected
+    @test observe() == caller_context
+    @test @inferred(
+        Backends._synchronize_prepared_device_execution_context!(context)) ===
+        nothing
+    return nothing
+end

--- a/test/backend_optional_common.jl
+++ b/test/backend_optional_common.jl
@@ -1,3 +1,7 @@
+if !isdefined(@__MODULE__, :assert_prepared_device_execution_context_conformance)
+    include(joinpath(@__DIR__, "backend_execution_context_conformance.jl"))
+end
+
 backend_package_name(::Type{AdaptiveOpticsSim.Backends.CUDABackendTag}) = "CUDA"
 backend_package_name(::Type{AdaptiveOpticsSim.Backends.AMDGPUBackendTag}) = "AMDGPU"
 
@@ -536,6 +540,16 @@ function run_optional_exact_compute_device_checks(
             context)
     @test prepared_device == selected_device
     @test compute_device(BackendArray(zeros(Float32, 1))) == caller_device
+    observe_context() = (
+        compute_device(BackendArray(zeros(Float32, 1))),
+        backend_current_stream(B),
+    )
+    assert_prepared_device_execution_context_conformance(
+        context,
+        selected_device,
+        observe_context,
+        (selected_device, retained_stream),
+    )
     context_observation =
         AdaptiveOpticsSim.Backends._with_prepared_device_execution_context(
             context) do

--- a/test/calibration_interface_conformance.jl
+++ b/test/calibration_interface_conformance.jl
@@ -1,0 +1,16 @@
+function assert_calibration_command_plan_conformance(
+    plan::P,
+    commands::AbstractMatrix{T},
+    amplitude::T,
+) where {P<:Calibration.AbstractCalibrationCommandPlan,T<:AbstractFloat}
+    @test Calibration.calibration_command_count(plan) == size(commands, 2)
+    coefficients = similar(commands, size(commands, 1))
+    for column in axes(commands, 2)
+        fill!(coefficients, T(NaN))
+        result = @inferred Calibration.stage_calibration_command!(
+            coefficients, plan, column, amplitude)
+        @test result === coefficients
+        @test coefficients == amplitude .* view(commands, :, column)
+    end
+    return nothing
+end

--- a/test/contracts/prepared_execution_ownership.toml
+++ b/test/contracts/prepared_execution_ownership.toml
@@ -10,7 +10,7 @@ claim = "PE-00 records and ratchets current ownership and type-erasure debt; it 
 
 [interface_decisions]
 work_issue = 229
-delivery_state = "planned"
+delivery_state = "implemented"
 columns = ["owner","name","decision","contract_kind","follow_on_gate","rationale"]
 allowed_decisions = ["retain","remove_now","reclassify_strategy","defer_removal"]
 allowed_contract_kinds = ["none","plan_protocol","prepared_owner_protocol"]
@@ -40,8 +40,10 @@ name = "AbstractCalibrationCommandPlan"
 visibility = "internal"
 implementations = ["ActuatorCalibrationCommands","MatrixCalibrationCommands"]
 required_methods = ["calibration_command_count","stage_calibration_command!"]
+conformance_helpers = ["assert_calibration_command_plan_conformance"]
 valid_defaults = []
 ownership = "The plan carries run-immutable command-count or command-basis data; each call overwrites caller-owned coefficient storage and returns that storage."
+aliasing = "Matrix command storage must not alias the destination DM coefficients; preparation rejects that binding before calibration mutation."
 failure_behavior = "Preparation and output validation use DimensionMismatchError or InvalidConfiguration before calibration mutation begins."
 reentrancy = "The plan is reentrant when its command basis is not mutated and invocations use distinct destination, DM, WFS, and pupil owners."
 backend_traits = ["command_storage_backend","destination_storage_backend"]
@@ -53,8 +55,10 @@ name = "AbstractPreparedFourPupilLGS"
 visibility = "internal"
 implementations = ["NoPreparedFourPupilLGS","PreparedFourPupilElongation","PreparedFourPupilSodiumProfile"]
 required_methods = ["apply_prepared_four_pupil_lgs!","_require_exact_prepared_four_pupil_lgs_target"]
+conformance_helpers = ["assert_prepared_four_pupil_lgs_conformance!"]
 valid_defaults = []
 ownership = "The plan owns immutable execution data; intensity and FFT scratch remain caller-owned single-writer workspace."
+aliasing = "Intensity, elongation scratch, and FFT work buffers are distinct exact prepared arrays; execution does not introduce views or replacement storage."
 failure_behavior = "Preparation and exact-target validation use WFSPreparationError before optical-product mutation; execution requires prepared compatible storage."
 reentrancy = "The plan data is reentrant with distinct intensity and FFT workspaces; one workspace must not have concurrent writers."
 backend_traits = ["execution_style","compute_device"]
@@ -66,8 +70,10 @@ name = "_AbstractPreparedDeviceExecutionContext"
 visibility = "internal_extension"
 implementations = ["_HostPreparedDeviceExecutionContext","CUDAPreparedDeviceExecutionContext","AMDGPUPreparedDeviceExecutionContext"]
 required_methods = ["_prepared_device_execution_compute_device","_with_prepared_device_execution_context","_synchronize_prepared_device_execution_context!"]
+conformance_helpers = ["assert_prepared_device_execution_context_conformance"]
 valid_defaults = ["Host context entry and synchronization are no-ops that preserve caller context."]
 ownership = "One prepared execution owner retains one exact device and any stream resources; context entry restores the caller's prior device and stream on success or failure."
+aliasing = "The context owns no numerical array storage; its retained stream/context resources must not be concurrently owned by another execution writer."
 failure_behavior = "Unsupported accelerator preparation uses ComputeDeviceError or InvalidConfiguration; context restoration is mandatory when the callback throws."
 reentrancy = "One context is single-owner and externally serialized; nested entry is supported by concrete implementations but concurrent ownership is not promised."
 backend_traits = ["compute_device_availability","execution_style"]
@@ -79,12 +85,14 @@ name = "AbstractPreparedAcquisitionLifecycle"
 visibility = "qualified_public"
 implementations = ["PreparedGlobalShutterAcquisition","PreparedRollingShutterAcquisition","PreparedFrameTransferAcquisition","PreparedDirectMeasurementAcquisition"]
 required_methods = ["begin_exposure!","complete_readout!","_require_exact_acquisition_lifecycle_target","structural_resource_fact"]
+conformance_helpers = ["assert_prepared_acquisition_lifecycle_conformance"]
 valid_defaults = ["Triggered starts require no periodic-spacing check.","Unknown structural resource facts fail admission closed rather than guessing bytes."]
 ownership = "A prepared lifecycle binds one exact definition and product/resource owner; a separate matching mutable state has one writer and every transition validates that binding before mutation."
+aliasing = "Only aliases explicitly retained by the prepared product/resource owner are valid; substitute state, product, workspace, or context identities are rejected."
 failure_behavior = "Invalid timing, transition, or foreign binding uses the lifecycle's structured Plant or detector acquisition error before mutation."
 reentrancy = "A prepared lifecycle and its matching state are single-writer and not reentrant; independent prepared/state pairs may execute independently."
 backend_traits = ["compute_device","structural_resource_fact"]
-conformance_suites = ["plant-detector-transitions","plant-reduced-order","prepared-execution-interfaces"]
+conformance_suites = ["plant-detector-transitions","plant-event-composition","plant-reduced-order","prepared-execution-interfaces"]
 
 [[interface_contracts]]
 owner = "Plant"
@@ -92,12 +100,14 @@ name = "AbstractPreparedDetectorAcquisitionLifecycle"
 visibility = "qualified_public"
 implementations = ["PreparedGlobalShutterAcquisition","PreparedRollingShutterAcquisition","PreparedFrameTransferAcquisition"]
 required_methods = ["begin_exposure!","complete_readout!","_require_exact_acquisition_lifecycle_target","structural_resource_fact"]
+conformance_helpers = ["assert_prepared_acquisition_lifecycle_conformance"]
 valid_defaults = []
 ownership = "The lifecycle binds one detector, detector-acquisition contract, readout products, and timing definition; the matching state owns persistent transition progress."
+aliasing = "Detector frame, accumulator, ramp, storage-frame, and readout-product aliases are fixed during preparation; frame-transfer storage is explicitly non-aliasing."
 failure_behavior = "DetectorAcquisitionError reports invalid timing, unsupported mode, transition order, and foreign state before detector or state mutation."
 reentrancy = "One detector lifecycle/state pair is single-writer and not reentrant."
 backend_traits = ["detector_execution_style","compute_device"]
-conformance_suites = ["plant-detector-transitions","prepared-execution-interfaces"]
+conformance_suites = ["plant-detector-transitions","plant-event-composition","prepared-execution-interfaces"]
 
 [[interface_contracts]]
 owner = "Plant"
@@ -105,12 +115,14 @@ name = "_PreparedEffectiveCommandPublicationRoute"
 visibility = "internal"
 implementations = ["_PreparedDirectEffectiveCommandPublicationRoute","_PreparedRemoteEffectiveCommandPublicationRoute"]
 required_methods = ["_prepare_effective_command_publication_route_state","_prepare_effective_command_publication_route!","_stage_effective_command_publication_route!","_reclaim_effective_command_publication_route!","_commit_effective_command_publication_route!","_abandon_effective_command_publication_route!"]
+conformance_helpers = ["run_effective_command_publication_route_conformance!"]
 valid_defaults = []
 ownership = "One route binds the command authority, destination replica, endpoint, optic, exact target context, and optional handoff; matching state is single-writer."
+aliasing = "Any direct replica relationship is fixed during preparation; runtime values, destination storage, route state, and remote handoff slots cannot be substituted."
 failure_behavior = "PlantPreparationError and PlantCommandError reject foreign bindings, unavailable destinations, invalid handoffs, and failed or uncertain transitions before publication commit."
 reentrancy = "One route/state pair is externally serialized and not reentrant."
 backend_traits = ["compute_device","handoff_payload_contract"]
-conformance_suites = ["plant-effective-command-routes","prepared-execution-interfaces"]
+conformance_suites = ["plant-effective-command-routes"]
 
 [[interface_contracts]]
 owner = "Plant"
@@ -118,12 +130,14 @@ name = "PreparedPupilOPDPublicationRoute"
 visibility = "qualified_public"
 implementations = ["PreparedDirectPupilOPDPublicationRoute","PreparedRemotePupilOPDPublicationRoute"]
 required_methods = ["prepare_pupil_opd_publication_output","materialize_pupil_opd_publication!","submit_pupil_opd_publication!","try_complete_pupil_opd_publication!","apply_pupil_opd_publication!","reclaim_pupil_opd_publication!"]
+conformance_helpers = ["run_pupil_opd_publication_route_conformance!"]
 valid_defaults = ["Unimplemented submission, completion, apply, and reclaim transitions return PupilOPDPublicationRejected."]
 ownership = "One route owns an opaque exact binding to its atmosphere authority, path, target-local pupil, materialization, mutable phase, and optional handoff slot."
+aliasing = "Direct materialization aliases only the prepared target-local input; remote source, destination, and handoff storage identities are fixed and separately validated."
 failure_behavior = "Preparation and binding defects use PlantPreparationError; lifecycle operations return typed status values and retain fail-stop ownership after uncertain transfer."
 reentrancy = "One route is externally serialized and not reentrant; the active publication is retained until apply and reclaim."
 backend_traits = ["compute_device","handoff_payload_contract"]
-conformance_suites = ["plant-path-input-publications","prepared-execution-interfaces"]
+conformance_suites = ["plant-path-input-publications"]
 
 [type_inventory]
 vocabulary_tokens = ["definition","definitions","parameters","params","plan","prepared","product","products","state","strategy","workspace"]
@@ -134,7 +148,7 @@ allowed_target_roles = ["definition","plan","plan_interface","state","workspace"
 allowed_product_visibility = ["internal","caller_visible"]
 allowed_backend_relevance = ["backend_neutral","backend_parameterized","backend_specific"]
 allowed_migration_gates = ["PE-00","PE-01","PE-02","PE-03","PE-04","PE-05","PE-06","PE-07"]
-baseline_type_count = 381
+baseline_type_count = 378
 baseline_mixed_type_count = 32
 
 [[type_inventory.files]]
@@ -183,7 +197,7 @@ entries = [
 path = "src/atmosphere/atmospheric_field_propagation.jl"
 owner = "Atmospheres"
 entries = [
-    ["AbstractAtmosphericFieldExecutionPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["AbstractAtmosphericFieldExecutionPlan","abstract_type",-1,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",false,"PE-02"],
     ["AtmosphericFieldPropagationParams","struct",5,"params",["definition"],false,false,"internal",false,"backend_neutral",false,"PE-00"],
     ["AtmosphericFieldPropagationState","struct",2,"state",["plan","workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
     ["GeometricFieldAsyncPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
@@ -271,7 +285,7 @@ entries = [
 path = "src/backends/reductions.jl"
 owner = "Backends"
 entries = [
-    ["AbstractReductionExecutionPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_specific",false,"PE-01"],
+    ["AbstractReductionExecutionPlan","abstract_type",-1,"plan",["strategy"],false,false,"internal",false,"backend_specific",false,"PE-02"],
     ["DirectReductionPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_specific",true,"PE-02"],
     ["HostMirrorReductionPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_specific",true,"PE-02"],
 ]
@@ -343,7 +357,7 @@ entries = [
 path = "src/detectors/pipeline.jl"
 owner = "Detectors"
 entries = [
-    ["AbstractDetectorExecutionPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["AbstractDetectorExecutionPlan","abstract_type",-1,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",false,"PE-02"],
     ["DetectorDirectPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
     ["DetectorHostMirrorPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
 ]
@@ -376,7 +390,6 @@ entries = [
 path = "src/optics/direct_imaging.jl"
 owner = "Optics"
 entries = [
-    ["AbstractDirectImagingInputPlan","abstract_type",-1,"plan",["prepared_owner_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
     ["DirectImagingPlan","struct",8,"plan",["plan","workspace","product","prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
     ["DirectImagingWorkspace","struct",2,"workspace",["workspace"],false,false,"internal",false,"backend_parameterized",true,"PE-03"],
     ["PreparedBundledDirectImaging","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-03"],
@@ -694,7 +707,7 @@ entries = [
     ["MixedResourcePlantEventLoopState","mutable_struct",9,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
     ["MixedResourcePlantEventLoopWorkspace","mutable_struct",9,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
     ["PreparedMixedResourcePlantEventLoop","struct",9,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
-    ["_AbstractPreparedMixedSerialEventAcquisition","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["_AbstractPreparedMixedSerialEventAcquisition","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-06"],
     ["_PreparedMixedResourcePlantEventLoopBinding","mutable_struct",0,"prepared",["binding_token"],true,false,"internal",true,"backend_neutral",false,"PE-06"],
     ["_PreparedMixedSerialEventAcquisition","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
     ["_PreparedMixedSerialEventCommand","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
@@ -707,7 +720,7 @@ path = "src/plant/mixed_serial_execution.jl"
 owner = "Plant"
 entries = [
     ["_AbstractMixedSerialPathWorkspace","abstract_type",-1,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
-    ["_AbstractPreparedMixedSerialPath","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
+    ["_AbstractPreparedMixedSerialPath","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-06"],
     ["_MixedSerialBatchWorkspace","mutable_struct",7,"workspace",["workspace"],true,false,"internal",true,"backend_parameterized",true,"PE-06"],
     ["_MixedSerialExecutionState","mutable_struct",5,"state",["state"],true,true,"internal",true,"backend_parameterized",true,"PE-06"],
     ["_MixedSerialExecutionWorkspace","struct",5,"workspace",["workspace"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
@@ -812,7 +825,6 @@ entries = [
     ["PreparedLinearReducedOrderProvider","struct",12,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
     ["PreparedReducedOrderCommandResponse","struct",6,"prepared",["plan"],false,false,"internal",false,"backend_parameterized",true,"PE-06"],
     ["_PreparedArrayReducedOrderEventResponse","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
-    ["_PreparedReducedOrderEventResponse","abstract_type",-1,"prepared",["prepared_owner_interface"],false,false,"internal",true,"backend_parameterized",false,"PE-01"],
     ["_PreparedScalarReducedOrderEventResponse","struct",2,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-06"],
 ]
 
@@ -920,7 +932,6 @@ entries = [
 path = "src/wfs/curvature/stages.jl"
 owner = "WavefrontSensors"
 entries = [
-    ["AbstractPreparedCurvatureObservationMapping","abstract_type",-1,"prepared",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
     ["PreparedCurvatureEstimator","struct",7,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
     ["PreparedCurvatureOpticalFormation","struct",4,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
     ["PreparedCurvaturePackedChannelAcquisition","struct",8,"prepared",["prepared_owner"],false,false,"internal",true,"backend_parameterized",true,"PE-05"],
@@ -941,7 +952,7 @@ entries = [
 path = "src/wfs/grouped.jl"
 owner = "WavefrontSensors"
 entries = [
-    ["AbstractGroupedAccumulationPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["AbstractGroupedAccumulationPlan","abstract_type",-1,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",false,"PE-02"],
     ["GroupedDirectAccumulatePlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
     ["GroupedStackReducePlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
     ["GroupedStaged2DPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],
@@ -980,7 +991,7 @@ entries = [
 path = "src/wfs/shack_hartmann/setup.jl"
 owner = "WavefrontSensors"
 entries = [
-    ["AbstractShackHartmannWFSSensingPlan","abstract_type",-1,"plan",["plan_interface"],false,false,"internal",false,"backend_parameterized",false,"PE-01"],
+    ["AbstractShackHartmannWFSSensingPlan","abstract_type",-1,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",false,"PE-02"],
     ["ShackHartmannAcquisitionState","mutable_struct",4,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
     ["ShackHartmannEstimatorState","mutable_struct",5,"state",["workspace","product"],true,false,"caller_visible",false,"backend_parameterized",true,"PE-05"],
     ["ShackHartmannWFSBatchedPlan","struct",0,"plan",["strategy"],false,false,"internal",false,"backend_parameterized",true,"PE-02"],

--- a/test/contracts/prepared_execution_ownership.toml
+++ b/test/contracts/prepared_execution_ownership.toml
@@ -8,6 +8,123 @@ policy_revision = "9ebb326ceaed33c99eecf88ec1242b737177980f"
 scope = ["src","ext"]
 claim = "PE-00 records and ratchets current ownership and type-erasure debt; it does not migrate runtime representation or promote hardware support"
 
+[interface_decisions]
+work_issue = 229
+delivery_state = "planned"
+columns = ["owner","name","decision","contract_kind","follow_on_gate","rationale"]
+allowed_decisions = ["retain","remove_now","reclassify_strategy","defer_removal"]
+allowed_contract_kinds = ["none","plan_protocol","prepared_owner_protocol"]
+entries = [
+    ["Atmospheres","AbstractAtmosphericFieldExecutionPlan","reclassify_strategy","none","PE-02","Zero-size synchronous/asynchronous dispatch selectors own no prepared numerical contract."],
+    ["Backends","AbstractReductionExecutionPlan","reclassify_strategy","none","PE-02","Zero-size direct/host-mirror selectors choose reduction execution without owning prepared coefficients or resources."],
+    ["Calibration","AbstractCalibrationCommandPlan","retain","plan_protocol","PE-01","Actuator and command-basis plans share command-count and command-staging behavior."],
+    ["Detectors","AbstractDetectorExecutionPlan","reclassify_strategy","none","PE-02","Zero-size direct/host-mirror selectors choose detector execution without owning a prepared detector contract."],
+    ["WavefrontSensors","AbstractPreparedCurvatureObservationMapping","remove_now","none","PE-01","The closed image-pair and channel-pair mappings share no operation through the abstract root."],
+    ["WavefrontSensors","AbstractPreparedFourPupilLGS","retain","plan_protocol","PE-01","No-op, elongation, and sodium-profile plans share prepared application and exact-target validation."],
+    ["WavefrontSensors","AbstractGroupedAccumulationPlan","reclassify_strategy","none","PE-02","Zero-size accumulation selectors choose one reduction implementation and own no prepared mapping or resource."],
+    ["WavefrontSensors","AbstractShackHartmannWFSSensingPlan","reclassify_strategy","none","PE-02","Zero-size sensing selectors choose scalar, batched, or device-statistics execution and own no prepared optical contract."],
+    ["Backends","_AbstractPreparedDeviceExecutionContext","retain","prepared_owner_protocol","PE-01","Host and accelerator extensions share exact-device entry, restoration, synchronization, and failure behavior."],
+    ["Optics","AbstractDirectImagingInputPlan","remove_now","none","PE-01","The two closed exact-input bindings are concrete prepared-owner variants rather than third-party algorithm plans."],
+    ["Plant","AbstractPreparedAcquisitionLifecycle","retain","prepared_owner_protocol","PE-01","Scheduled acquisition implementations share exact state/product binding, lifecycle transitions, target validation, and single-writer semantics."],
+    ["Plant","AbstractPreparedDetectorAcquisitionLifecycle","retain","prepared_owner_protocol","PE-01","Global, rolling, and frame-transfer detector lifecycles share the detector-backed acquisition subprotocol."],
+    ["Plant","_PreparedEffectiveCommandPublicationRoute","retain","prepared_owner_protocol","PE-01","Direct and remote routes share prepare, stage, commit, reclaim, abandon, and exact-binding transitions."],
+    ["Plant","_AbstractPreparedMixedSerialEventAcquisition","defer_removal","none","PE-06","The root has one implementation and exists only as erased registry storage; removal belongs to the concrete family-group migration."],
+    ["Plant","_AbstractPreparedMixedSerialPath","defer_removal","none","PE-06","The root has one implementation and exists only as erased registry storage; removal belongs to the concrete family-group migration."],
+    ["Plant","PreparedPupilOPDPublicationRoute","retain","prepared_owner_protocol","PE-01","Direct and remote routes share one authority-owned materialize, transfer, apply, reclaim lifecycle."],
+    ["Plant","_PreparedReducedOrderEventResponse","remove_now","none","PE-01","The scalar and array response records share no behavior through the abstract root and are stored concretely in a tuple."],
+]
+
+[[interface_contracts]]
+owner = "Calibration"
+name = "AbstractCalibrationCommandPlan"
+visibility = "internal"
+implementations = ["ActuatorCalibrationCommands","MatrixCalibrationCommands"]
+required_methods = ["calibration_command_count","stage_calibration_command!"]
+valid_defaults = []
+ownership = "The plan carries run-immutable command-count or command-basis data; each call overwrites caller-owned coefficient storage and returns that storage."
+failure_behavior = "Preparation and output validation use DimensionMismatchError or InvalidConfiguration before calibration mutation begins."
+reentrancy = "The plan is reentrant when its command basis is not mutated and invocations use distinct destination, DM, WFS, and pupil owners."
+backend_traits = ["command_storage_backend","destination_storage_backend"]
+conformance_suites = ["calibration-workflows","prepared-execution-interfaces"]
+
+[[interface_contracts]]
+owner = "WavefrontSensors"
+name = "AbstractPreparedFourPupilLGS"
+visibility = "internal"
+implementations = ["NoPreparedFourPupilLGS","PreparedFourPupilElongation","PreparedFourPupilSodiumProfile"]
+required_methods = ["apply_prepared_four_pupil_lgs!","_require_exact_prepared_four_pupil_lgs_target"]
+valid_defaults = []
+ownership = "The plan owns immutable execution data; intensity and FFT scratch remain caller-owned single-writer workspace."
+failure_behavior = "Preparation and exact-target validation use WFSPreparationError before optical-product mutation; execution requires prepared compatible storage."
+reentrancy = "The plan data is reentrant with distinct intensity and FFT workspaces; one workspace must not have concurrent writers."
+backend_traits = ["execution_style","compute_device"]
+conformance_suites = ["wfs-pyramid-bioedge","prepared-execution-interfaces"]
+
+[[interface_contracts]]
+owner = "Backends"
+name = "_AbstractPreparedDeviceExecutionContext"
+visibility = "internal_extension"
+implementations = ["_HostPreparedDeviceExecutionContext","CUDAPreparedDeviceExecutionContext","AMDGPUPreparedDeviceExecutionContext"]
+required_methods = ["_prepared_device_execution_compute_device","_with_prepared_device_execution_context","_synchronize_prepared_device_execution_context!"]
+valid_defaults = ["Host context entry and synchronization are no-ops that preserve caller context."]
+ownership = "One prepared execution owner retains one exact device and any stream resources; context entry restores the caller's prior device and stream on success or failure."
+failure_behavior = "Unsupported accelerator preparation uses ComputeDeviceError or InvalidConfiguration; context restoration is mandatory when the callback throws."
+reentrancy = "One context is single-owner and externally serialized; nested entry is supported by concrete implementations but concurrent ownership is not promised."
+backend_traits = ["compute_device_availability","execution_style"]
+conformance_suites = ["backend-smoke","prepared-execution-interfaces"]
+
+[[interface_contracts]]
+owner = "Plant"
+name = "AbstractPreparedAcquisitionLifecycle"
+visibility = "qualified_public"
+implementations = ["PreparedGlobalShutterAcquisition","PreparedRollingShutterAcquisition","PreparedFrameTransferAcquisition","PreparedDirectMeasurementAcquisition"]
+required_methods = ["begin_exposure!","complete_readout!","_require_exact_acquisition_lifecycle_target","structural_resource_fact"]
+valid_defaults = ["Triggered starts require no periodic-spacing check.","Unknown structural resource facts fail admission closed rather than guessing bytes."]
+ownership = "A prepared lifecycle binds one exact definition and product/resource owner; a separate matching mutable state has one writer and every transition validates that binding before mutation."
+failure_behavior = "Invalid timing, transition, or foreign binding uses the lifecycle's structured Plant or detector acquisition error before mutation."
+reentrancy = "A prepared lifecycle and its matching state are single-writer and not reentrant; independent prepared/state pairs may execute independently."
+backend_traits = ["compute_device","structural_resource_fact"]
+conformance_suites = ["plant-detector-transitions","plant-reduced-order","prepared-execution-interfaces"]
+
+[[interface_contracts]]
+owner = "Plant"
+name = "AbstractPreparedDetectorAcquisitionLifecycle"
+visibility = "qualified_public"
+implementations = ["PreparedGlobalShutterAcquisition","PreparedRollingShutterAcquisition","PreparedFrameTransferAcquisition"]
+required_methods = ["begin_exposure!","complete_readout!","_require_exact_acquisition_lifecycle_target","structural_resource_fact"]
+valid_defaults = []
+ownership = "The lifecycle binds one detector, detector-acquisition contract, readout products, and timing definition; the matching state owns persistent transition progress."
+failure_behavior = "DetectorAcquisitionError reports invalid timing, unsupported mode, transition order, and foreign state before detector or state mutation."
+reentrancy = "One detector lifecycle/state pair is single-writer and not reentrant."
+backend_traits = ["detector_execution_style","compute_device"]
+conformance_suites = ["plant-detector-transitions","prepared-execution-interfaces"]
+
+[[interface_contracts]]
+owner = "Plant"
+name = "_PreparedEffectiveCommandPublicationRoute"
+visibility = "internal"
+implementations = ["_PreparedDirectEffectiveCommandPublicationRoute","_PreparedRemoteEffectiveCommandPublicationRoute"]
+required_methods = ["_prepare_effective_command_publication_route_state","_prepare_effective_command_publication_route!","_stage_effective_command_publication_route!","_reclaim_effective_command_publication_route!","_commit_effective_command_publication_route!","_abandon_effective_command_publication_route!"]
+valid_defaults = []
+ownership = "One route binds the command authority, destination replica, endpoint, optic, exact target context, and optional handoff; matching state is single-writer."
+failure_behavior = "PlantPreparationError and PlantCommandError reject foreign bindings, unavailable destinations, invalid handoffs, and failed or uncertain transitions before publication commit."
+reentrancy = "One route/state pair is externally serialized and not reentrant."
+backend_traits = ["compute_device","handoff_payload_contract"]
+conformance_suites = ["plant-effective-command-routes","prepared-execution-interfaces"]
+
+[[interface_contracts]]
+owner = "Plant"
+name = "PreparedPupilOPDPublicationRoute"
+visibility = "qualified_public"
+implementations = ["PreparedDirectPupilOPDPublicationRoute","PreparedRemotePupilOPDPublicationRoute"]
+required_methods = ["prepare_pupil_opd_publication_output","materialize_pupil_opd_publication!","submit_pupil_opd_publication!","try_complete_pupil_opd_publication!","apply_pupil_opd_publication!","reclaim_pupil_opd_publication!"]
+valid_defaults = ["Unimplemented submission, completion, apply, and reclaim transitions return PupilOPDPublicationRejected."]
+ownership = "One route owns an opaque exact binding to its atmosphere authority, path, target-local pupil, materialization, mutable phase, and optional handoff slot."
+failure_behavior = "Preparation and binding defects use PlantPreparationError; lifecycle operations return typed status values and retain fail-stop ownership after uncertain transfer."
+reentrancy = "One route is externally serialized and not reentrant; the active publication is retained until apply and reclaim."
+backend_traits = ["compute_device","handoff_payload_contract"]
+conformance_suites = ["plant-path-input-publications","prepared-execution-interfaces"]
+
 [type_inventory]
 vocabulary_tokens = ["definition","definitions","parameters","params","plan","prepared","product","products","state","strategy","workspace"]
 columns = ["name","declaration","field_count","current_role","target_roles","mutable","persistent_state","product_visibility","exact_binding","backend_relevance","cpu_hot_path","migration_gate"]

--- a/test/plant_acquisition_interface_conformance.jl
+++ b/test/plant_acquisition_interface_conformance.jl
@@ -1,0 +1,97 @@
+@inline acquisition_conformance_snapshot(
+    state::Plant.GlobalShutterAcquisitionState,
+) = (
+    state.status,
+    state.sequence,
+    state.exposure_start,
+    state.exposure_close,
+    state.integrated_through,
+    state.readout_complete,
+    state.readiness,
+    state.next_read_index,
+)
+
+@inline acquisition_conformance_snapshot(
+    state::Plant.RollingShutterAcquisitionState,
+) = (
+    state.status,
+    state.sequence,
+    state.frame_start,
+    state.integrated_through,
+    state.readout_complete,
+    state.readiness,
+    state.opened_bands,
+    state.closed_bands,
+)
+
+@inline acquisition_conformance_snapshot(
+    state::Plant.FrameTransferAcquisitionState,
+) = (
+    state.image_status,
+    state.storage_status,
+    state.sequence,
+    state.image_sequence,
+    state.storage_sequence,
+    state.product_sequence,
+    state.exposure_start,
+    state.exposure_close,
+    state.integrated_through,
+    state.transfer_complete,
+    state.storage_readout_complete,
+    state.product_ready,
+)
+
+@inline acquisition_conformance_snapshot(
+    state::Plant.DirectMeasurementAcquisitionState,
+) = (
+    state.status,
+    state.sequence,
+    state.exposure_start,
+    state.exposure_close,
+    state.integrated_through,
+    state.readout_complete,
+    state.readiness,
+)
+
+function assert_prepared_acquisition_lifecycle_conformance(
+    prepared::P,
+    state::S,
+    foreign_state::S,
+    target::D,
+    expected_error::Type{E};
+    detector_backed::Bool,
+) where {
+    P<:Plant.AbstractPreparedAcquisitionLifecycle,
+    S<:Plant.AbstractAcquisitionLifecycleState,
+    D<:Backends.AbstractComputeDevice,
+    E<:Exception,
+}
+    @test (prepared isa Plant.AbstractPreparedDetectorAcquisitionLifecycle) ==
+        detector_backed
+    @test @inferred(Plant._require_exact_acquisition_lifecycle_target(
+        prepared, target)) === prepared
+    @test applicable(Plant.begin_exposure!, prepared, state,
+        zero(Plant.PlantTimestamp))
+    @test applicable(Plant.complete_readout!, prepared, state,
+        zero(Plant.PlantTimestamp), Xoshiro(0))
+
+    owner = Plant.StructuralResourceOwnerID(:acquisition, :pe01_interface)
+    fact = Plant.structural_resource_fact(prepared, state, owner, target)
+    @test fact isa Plant.AbstractStructuralResourceFact
+    @test Backends.compute_device(fact) == target
+
+    before = acquisition_conformance_snapshot(foreign_state)
+    caught = try
+        Plant.begin_exposure!(prepared, foreign_state,
+            zero(Plant.PlantTimestamp))
+        nothing
+    catch error
+        error
+    end
+    @test caught isa E
+    if caught isa E
+        @test caught.reason === :foreign_state
+    end
+    @test acquisition_conformance_snapshot(foreign_state) == before
+    return fact
+end

--- a/test/plant_effective_command_route_fixtures.jl
+++ b/test/plant_effective_command_route_fixtures.jl
@@ -449,7 +449,7 @@ end
         Base.tail(routes), Base.tail(states))
 end
 
-function effective_command_route_test_publish!(
+function run_effective_command_publication_route_conformance!(
     routes::Plant._PreparedEffectiveCommandPublicationRoutes,
     states::Plant._EffectiveCommandPublicationRoutesState,
     value,

--- a/test/test_selection.jl
+++ b/test/test_selection.jl
@@ -43,6 +43,16 @@ const TEST_SUITE_SPECS = (
         "testsets/prepared_execution_contracts.jl";
         fixtures=("prepared_execution_contract_helpers.jl",),
     ),
+    TestSuiteSpec(
+        "prepared-execution-interfaces",
+        "testsets/prepared_execution_interfaces.jl";
+        fixtures=(
+            "calibration_interface_conformance.jl",
+            "wfs_four_pupil_interface_conformance.jl",
+            "backend_execution_context_conformance.jl",
+            "plant_acquisition_interface_conformance.jl",
+        ),
+    ),
     TestSuiteSpec("namespace-authority",
         "testsets/namespace_authority.jl"),
     TestSuiteSpec("core-optics", "testsets/core_optics.jl"),
@@ -387,6 +397,15 @@ const TEST_GROUP_SPECS = (
     ),
     "references" => ("reference-tutorials", "gate0"),
     "backends" => ("ka-cpu", "backend-smoke"),
+    "pe01" => (
+        "prepared-execution-contracts",
+        "prepared-execution-interfaces",
+        "direct-imaging-batch",
+        "plant-reduced-order",
+        "wfs-zernike-curvature",
+        "plant-effective-command-routes",
+        "plant-path-input-publications",
+    ),
     "gate4" => (
         "plant-command-schemas",
         "plant-command-admission",
@@ -424,6 +443,7 @@ const TEST_CI_SHARD_SPECS = (
         "tomography",
         "quality",
         "prepared-execution-contracts",
+        "prepared-execution-interfaces",
         "namespace-authority",
         "core-optics",
         "direct-science",

--- a/test/testsets/calibration_workflows.jl
+++ b/test/testsets/calibration_workflows.jl
@@ -156,6 +156,12 @@ end
         amplitude=0.1)
     assert_interaction_matrix_contract(imat_basis, length(slopes(wfs)), size(basis.M2C, 2), 0.1)
 
+    aliased_commands = reshape(dm.state.coefs, :, 1)
+    coefficients_before_alias_rejection = copy(dm.state.coefs)
+    @test_throws InvalidConfiguration interaction_matrix(
+        dm, wfs, pupil, aliased_commands; amplitude=0.1)
+    @test dm.state.coefs == coefficients_before_alias_rejection
+
     control_matrix = ControlMatrix(imat.matrix)
     assert_control_matrix_contract(control_matrix, imat.matrix)
     noninverted_control_matrix = ControlMatrix(imat.matrix; invert=false)

--- a/test/testsets/plant_effective_command_routes.jl
+++ b/test/testsets/plant_effective_command_routes.jl
@@ -54,7 +54,7 @@ end
         authority, authority_state, [2.0, 3.0])
     @test candidate == [3.0, 4.0]
     timestamp = PlantTimestamp(10)
-    effective_command_route_test_publish!(
+    run_effective_command_publication_route_conformance!(
         routes, route_states, candidate, timestamp, UInt64(1))
 
     values, physical = effective_command_route_test_replica_values(partitions)
@@ -101,7 +101,7 @@ end
     scalar_authority_state = CommandAuthorityState(scalar_authority)
     scalar_candidate = effective_command_route_test_candidate!(
         scalar_authority, scalar_authority_state, 2.0)
-    effective_command_route_test_publish!(
+    run_effective_command_publication_route_conformance!(
         scalar_routes,
         scalar_route_states,
         scalar_candidate,
@@ -507,7 +507,7 @@ end
     route_states =
         Plant._prepare_effective_command_publication_routes_state(routes)
     candidate = [4.0, 5.0]
-    effective_command_route_test_publish!(
+    run_effective_command_publication_route_conformance!(
         routes, route_states, candidate, PlantTimestamp(1), UInt64(1))
     storage = routes.storage
     state_storage = route_states.storage
@@ -533,7 +533,7 @@ end
         storage, state_storage)
     commit_allocations = @allocated effective_command_route_test_commit!(
         storage, state_storage)
-    @test @inferred(effective_command_route_test_publish!(
+    @test @inferred(run_effective_command_publication_route_conformance!(
         routes,
         route_states,
         candidate,

--- a/test/testsets/plant_path_input_publications.jl
+++ b/test/testsets/plant_path_input_publications.jl
@@ -53,7 +53,7 @@ function forged_pupil_opd_publication(
     )
 end
 
-function pupil_opd_publication_allocation_sample!(
+function run_pupil_opd_publication_route_conformance!(
     direct::Plant.PreparedDirectPupilOPDPublicationRoute,
     remote::Plant.PreparedRemotePupilOPDPublicationRoute,
     epoch::AtmosphereEpoch,
@@ -698,12 +698,12 @@ end
     warm_timestamp = PlantTimestamp(0)
     warm_epoch = path_input_publication_test_epoch!(
         partitions, warm_timestamp)
-    pupil_opd_publication_allocation_sample!(
+    run_pupil_opd_publication_route_conformance!(
         direct, remote, warm_epoch, warm_timestamp)
 
     timestamp = PlantTimestamp(1_000_000)
     epoch = path_input_publication_test_epoch!(partitions, timestamp)
-    allocations = pupil_opd_publication_allocation_sample!(
+    allocations = run_pupil_opd_publication_route_conformance!(
         direct, remote, epoch, timestamp)
     if !coverage_instrumented()
         @test allocations == (0, 0, 0, 0, 0, 0, 0)

--- a/test/testsets/prepared_execution_contracts.jl
+++ b/test/testsets/prepared_execution_contracts.jl
@@ -92,6 +92,133 @@ end
     @test contract["name"] == "prepared_execution_ownership"
     @test contract["status"] == "characterized_baseline"
 
+    decisions = contract["interface_decisions"]
+    @test decisions["work_issue"] == 229
+    @test decisions["delivery_state"] == "implemented"
+    decision_columns = String.(decisions["columns"])
+    @test decision_columns == [
+        "owner",
+        "name",
+        "decision",
+        "contract_kind",
+        "follow_on_gate",
+        "rationale",
+    ]
+    allowed_decisions = Set(String.(decisions["allowed_decisions"]))
+    allowed_contract_kinds =
+        Set(String.(decisions["allowed_contract_kinds"]))
+    decision_rows = Dict{
+        Tuple{String,String},
+        NamedTuple{
+            (:decision, :contract_kind, :follow_on_gate, :rationale),
+            Tuple{String,String,String,String},
+        },
+    }()
+    for row in decisions["entries"]
+        @test length(row) == length(decision_columns)
+        values = Dict(decision_columns .=> row)
+        key = (String(values["owner"]), String(values["name"]))
+        @test !haskey(decision_rows, key)
+        @test values["decision"] in allowed_decisions
+        @test values["contract_kind"] in allowed_contract_kinds
+        @test !isempty(values["follow_on_gate"])
+        @test !isempty(values["rationale"])
+        decision_rows[key] = (
+            decision=String(values["decision"]),
+            contract_kind=String(values["contract_kind"]),
+            follow_on_gate=String(values["follow_on_gate"]),
+            rationale=String(values["rationale"]),
+        )
+    end
+    @test length(decision_rows) == 17
+
+    retained_interfaces = Set((
+        ("Backends", "_AbstractPreparedDeviceExecutionContext"),
+        ("Calibration", "AbstractCalibrationCommandPlan"),
+        ("Plant", "AbstractPreparedAcquisitionLifecycle"),
+        ("Plant", "AbstractPreparedDetectorAcquisitionLifecycle"),
+        ("Plant", "PreparedPupilOPDPublicationRoute"),
+        ("Plant", "_PreparedEffectiveCommandPublicationRoute"),
+        ("WavefrontSensors", "AbstractPreparedFourPupilLGS"),
+    ))
+    removed_interfaces = Set((
+        ("Optics", "AbstractDirectImagingInputPlan"),
+        ("Plant", "_PreparedReducedOrderEventResponse"),
+        ("WavefrontSensors",
+            "AbstractPreparedCurvatureObservationMapping"),
+    ))
+    strategy_interfaces = Set((
+        ("Atmospheres", "AbstractAtmosphericFieldExecutionPlan"),
+        ("Backends", "AbstractReductionExecutionPlan"),
+        ("Detectors", "AbstractDetectorExecutionPlan"),
+        ("WavefrontSensors", "AbstractGroupedAccumulationPlan"),
+        ("WavefrontSensors", "AbstractShackHartmannWFSSensingPlan"),
+    ))
+    deferred_interfaces = Set((
+        ("Plant", "_AbstractPreparedMixedSerialEventAcquisition"),
+        ("Plant", "_AbstractPreparedMixedSerialPath"),
+    ))
+    decision_keys(value) = Set(key for (key, row) in decision_rows
+        if row.decision == value)
+    @test decision_keys("retain") == retained_interfaces
+    @test decision_keys("remove_now") == removed_interfaces
+    @test decision_keys("reclassify_strategy") == strategy_interfaces
+    @test decision_keys("defer_removal") == deferred_interfaces
+    @test all(decision_rows[key].follow_on_gate == "PE-01"
+        for key in union(retained_interfaces, removed_interfaces))
+    @test all(decision_rows[key].follow_on_gate == "PE-02"
+        for key in strategy_interfaces)
+    @test all(decision_rows[key].follow_on_gate == "PE-06"
+        for key in deferred_interfaces)
+
+    suite_names = Set(spec.name for spec in TEST_SUITE_SPECS)
+    interface_contracts = Dict{
+        Tuple{String,String},
+        NamedTuple{
+            (:implementations, :required_methods),
+            Tuple{Vector{String},Vector{String}},
+        },
+    }()
+    conformance_source_parts = String[]
+    for (root, _, files) in walkdir(joinpath(PE_REPOSITORY_ROOT, "test"))
+        for file in files
+            endswith(file, ".jl") || continue
+            push!(conformance_source_parts,
+                read(joinpath(root, file), String))
+        end
+    end
+    conformance_source = join(conformance_source_parts, '\n')
+    for entry in contract["interface_contracts"]
+        key = (String(entry["owner"]), String(entry["name"]))
+        @test !haskey(interface_contracts, key)
+        @test entry["visibility"] in
+            ("internal", "internal_extension", "qualified_public")
+        @test !isempty(entry["implementations"])
+        @test all(!isempty, entry["implementations"])
+        @test length(unique(entry["implementations"])) ==
+            length(entry["implementations"])
+        @test !isempty(entry["required_methods"])
+        @test all(!isempty, entry["required_methods"])
+        @test length(unique(entry["required_methods"])) ==
+            length(entry["required_methods"])
+        @test entry["valid_defaults"] isa Vector
+        @test !isempty(entry["ownership"])
+        @test !isempty(entry["aliasing"])
+        @test !isempty(entry["failure_behavior"])
+        @test !isempty(entry["reentrancy"])
+        @test !isempty(entry["backend_traits"])
+        @test !isempty(entry["conformance_helpers"])
+        @test all(helper -> occursin(helper, conformance_source),
+            entry["conformance_helpers"])
+        @test !isempty(entry["conformance_suites"])
+        @test all(in(suite_names), entry["conformance_suites"])
+        interface_contracts[key] = (
+            implementations=String.(entry["implementations"]),
+            required_methods=String.(entry["required_methods"]),
+        )
+    end
+    @test Set(keys(interface_contracts)) == retained_interfaces
+
     inventory = contract["type_inventory"]
     @test Set(String.(inventory["vocabulary_tokens"])) ==
         PE_VOCABULARY
@@ -156,8 +283,13 @@ end
                 @test values["field_count"] == 0
                 @test values["exact_binding"]
             end
-            "strategy" in values["target_roles"] &&
-                @test values["field_count"] == 0
+            if "strategy" in values["target_roles"]
+                if values["declaration"] == "abstract_type"
+                    @test values["field_count"] == -1
+                else
+                    @test values["field_count"] == 0
+                end
+            end
             values["current_role"] == "plan" &&
                     values["field_count"] == 0 &&
                 @test !isdisjoint(values["target_roles"],
@@ -171,6 +303,64 @@ end
     end
     @test mixed_target_count == inventory["baseline_mixed_type_count"]
     @test length(expected) == inventory["baseline_type_count"]
+
+    inventory_by_name = Dict{
+        String,
+        NamedTuple{
+            (:path, :declaration, :target_roles, :migration_gate),
+            Tuple{String,String,Vector{String},String},
+        },
+    }()
+    for file in inventory["files"]
+        path = String(file["path"])
+        for row in file["entries"]
+            values = Dict(columns .=> row)
+            name = String(values["name"])
+            @test !haskey(inventory_by_name, name)
+            inventory_by_name[name] = (
+                path=path,
+                declaration=String(values["declaration"]),
+                target_roles=String.(values["target_roles"]),
+                migration_gate=String(values["migration_gate"]),
+            )
+        end
+    end
+
+    owner_modules = Dict(
+        "Atmospheres" => Atmospheres,
+        "Backends" => Backends,
+        "Calibration" => Calibration,
+        "Detectors" => Detectors,
+        "Optics" => Optics,
+        "Plant" => Plant,
+        "WavefrontSensors" => WavefrontSensors,
+    )
+    for key in retained_interfaces
+        owner, name = key
+        @test haskey(inventory_by_name, name)
+        @test inventory_by_name[name].declaration == "abstract_type"
+        root = getfield(owner_modules[owner], Symbol(name))
+        @test isabstracttype(root)
+        contract_entry = interface_contracts[key]
+        @test all(implementation ->
+                haskey(inventory_by_name, implementation) ||
+                isdefined(owner_modules[owner], Symbol(implementation)),
+            contract_entry.implementations)
+        @test all(method_name -> isdefined(owner_modules[owner],
+                Symbol(method_name)), contract_entry.required_methods)
+    end
+    for (owner, name) in removed_interfaces
+        @test !haskey(inventory_by_name, name)
+        @test !isdefined(owner_modules[owner], Symbol(name))
+    end
+    for (_, name) in strategy_interfaces
+        @test inventory_by_name[name].target_roles == ["strategy"]
+        @test inventory_by_name[name].migration_gate == "PE-02"
+    end
+    for (_, name) in deferred_interfaces
+        @test inventory_by_name[name].declaration == "abstract_type"
+        @test inventory_by_name[name].migration_gate == "PE-06"
+    end
 
     observed = Dict(
         (declaration.path, declaration.name) =>

--- a/test/testsets/prepared_execution_interfaces.jl
+++ b/test/testsets/prepared_execution_interfaces.jl
@@ -1,0 +1,172 @@
+function pe01_detector_rate_map(values::AbstractMatrix{T}) where {
+    T<:AbstractFloat,
+}
+    metadata = OpticalPlaneMetadata(DetectorPlane(), values;
+        coordinate_domain=AngularCoordinates(),
+        sampling=(one(T), one(T)),
+        normalization=PhotonRateNormalization(),
+        spatial_measure=CellIntegratedMeasure(),
+        coherence=IncoherentIntensityAddition(),
+        spectral=MonochromaticChannel(T(0.55e-6)))
+    return IntensityMap(metadata, values)
+end
+
+@testset "PE-01 calibration command-plan interface" begin
+    actuator_commands = Matrix{Float64}(I, 3, 3)
+    assert_calibration_command_plan_conformance(
+        Calibration.ActuatorCalibrationCommands(3),
+        actuator_commands,
+        0.25,
+    )
+
+    matrix_commands = [1.0 3.0; 2.0 4.0; 5.0 6.0]
+    assert_calibration_command_plan_conformance(
+        Calibration.MatrixCalibrationCommands(matrix_commands),
+        matrix_commands,
+        0.5,
+    )
+end
+
+@testset "PE-01 four-pupil LGS plan interface" begin
+    target = HostComputeDevice()
+    intensity = ones(4, 4)
+    scratch = similar(intensity)
+    fft_buffer = zeros(ComplexF64, size(intensity))
+    ifft_buffer = similar(fft_buffer)
+    fft_plan = Backends.plan_fft_backend!(fft_buffer)
+    ifft_plan = Backends.plan_ifft_backend!(ifft_buffer)
+
+    no_lgs = WavefrontSensors.NoPreparedFourPupilLGS()
+    baseline = copy(intensity)
+    assert_prepared_four_pupil_lgs_conformance!(no_lgs, intensity,
+        scratch, fft_buffer, fft_plan, ifft_buffer, ifft_plan, target)
+    @test intensity == baseline
+
+    elongation = WavefrontSensors.PreparedFourPupilElongation(
+        [0.25, 0.5, 0.25], 1)
+    fill!(intensity, 1.0)
+    assert_prepared_four_pupil_lgs_conformance!(elongation, intensity,
+        scratch, fft_buffer, fft_plan, ifft_buffer, ifft_plan, target)
+    @test intensity == ones(4, 4)
+
+    sodium = WavefrontSensors.PreparedFourPupilSodiumProfile(
+        ones(ComplexF64, size(intensity)))
+    intensity .= reshape(collect(1.0:16.0), 4, 4)
+    baseline = copy(intensity)
+    assert_prepared_four_pupil_lgs_conformance!(sodium, intensity,
+        scratch, fft_buffer, fft_plan, ifft_buffer, ifft_plan, target)
+    @test intensity ≈ baseline atol=1e-12 rtol=1e-12
+
+    unavailable = AcceleratorComputeDevice(CUDABackend(), 0)
+    @test WavefrontSensors._require_exact_prepared_four_pupil_lgs_target(
+        no_lgs, unavailable) === nothing
+    @test_throws WFSPreparationError begin
+        WavefrontSensors._require_exact_prepared_four_pupil_lgs_target(
+            elongation, unavailable)
+    end
+    @test_throws WFSPreparationError begin
+        WavefrontSensors._require_exact_prepared_four_pupil_lgs_target(
+            sodium, unavailable)
+    end
+end
+
+@testset "PE-01 prepared device-context interface" begin
+    target = HostComputeDevice()
+    context = Backends._prepare_device_execution_context(target)
+    observe_host() = HostComputeDevice()
+    @test @inferred(Backends._with_prepared_device_execution_context(
+        observe_host, context)) == target
+    assert_prepared_device_execution_context_conformance(
+        context, target, observe_host, target)
+
+    @test_throws ComputeDeviceError begin
+        Backends._prepare_device_execution_context(
+            AcceleratorComputeDevice(CUDABackend(), 0))
+    end
+end
+
+@testset "PE-01 acquisition-lifecycle interfaces" begin
+    target = HostComputeDevice()
+    definition = GlobalShutterAcquisitionDefinition(
+        PlantDuration(1_000_000_000))
+    map = pe01_detector_rate_map(ones(2, 2))
+    detector = Detector(integration_time=1.0, noise=NoiseNone())
+    foreign_detector = Detector(integration_time=1.0, noise=NoiseNone())
+    prepared = prepare_global_shutter_acquisition(
+        detector, map, definition)
+    foreign_prepared = prepare_global_shutter_acquisition(
+        foreign_detector, map, definition)
+    assert_prepared_acquisition_lifecycle_conformance(
+        prepared,
+        GlobalShutterAcquisitionState(prepared),
+        GlobalShutterAcquisitionState(foreign_prepared),
+        target,
+        DetectorAcquisitionError;
+        detector_backed=true,
+    )
+
+    rolling_definition = RollingShutterAcquisitionDefinition(
+        PlantDuration(1_000_000_000))
+    rolling_sensor = CMOSSensor(
+        timing_model=RollingShutter(0.01; row_group_size=1))
+    foreign_rolling_sensor = CMOSSensor(
+        timing_model=RollingShutter(0.01; row_group_size=1))
+    rolling_detector = Detector(integration_time=1.0, noise=NoiseNone(),
+        sensor=rolling_sensor)
+    foreign_rolling_detector = Detector(integration_time=1.0,
+        noise=NoiseNone(), sensor=foreign_rolling_sensor)
+    rolling = prepare_rolling_shutter_acquisition(
+        rolling_detector, map, rolling_definition)
+    foreign_rolling = prepare_rolling_shutter_acquisition(
+        foreign_rolling_detector, map, rolling_definition)
+    assert_prepared_acquisition_lifecycle_conformance(
+        rolling,
+        RollingShutterAcquisitionState(rolling),
+        RollingShutterAcquisitionState(foreign_rolling),
+        target,
+        DetectorAcquisitionError;
+        detector_backed=true,
+    )
+
+    transfer_definition = FrameTransferAcquisitionDefinition(
+        PlantDuration(1_000_000_000))
+    transfer_sensor = EMCCDSensor(excess_noise_factor=1.0,
+        acquisition_mode=FrameTransferAcquisition(transfer_time=0.1))
+    foreign_transfer_sensor = EMCCDSensor(excess_noise_factor=1.0,
+        acquisition_mode=FrameTransferAcquisition(transfer_time=0.1))
+    transfer_detector = Detector(integration_time=1.0, noise=NoiseNone(),
+        sensor=transfer_sensor)
+    foreign_transfer_detector = Detector(integration_time=1.0,
+        noise=NoiseNone(), sensor=foreign_transfer_sensor)
+    transfer = prepare_frame_transfer_acquisition(
+        transfer_detector, map, transfer_definition)
+    foreign_transfer = prepare_frame_transfer_acquisition(
+        foreign_transfer_detector, map, transfer_definition)
+    assert_prepared_acquisition_lifecycle_conformance(
+        transfer,
+        FrameTransferAcquisitionState(transfer),
+        FrameTransferAcquisitionState(foreign_transfer),
+        target,
+        DetectorAcquisitionError;
+        detector_backed=true,
+    )
+
+    direct_definition = DirectMeasurementAcquisitionDefinition(
+        PlantDuration(1_000_000_000))
+    measurement = WFSMeasurement(zeros(2);
+        units=:metre, kind=:modal_residual)
+    foreign_measurement = WFSMeasurement(zeros(2);
+        units=:metre, kind=:modal_residual)
+    direct = prepare_direct_measurement_acquisition(
+        measurement, direct_definition)
+    foreign_direct = prepare_direct_measurement_acquisition(
+        foreign_measurement, direct_definition)
+    assert_prepared_acquisition_lifecycle_conformance(
+        direct,
+        DirectMeasurementAcquisitionState(direct),
+        DirectMeasurementAcquisitionState(foreign_direct),
+        target,
+        PlantScheduleError;
+        detector_backed=false,
+    )
+end

--- a/test/testsets/quality.jl
+++ b/test/testsets/quality.jl
@@ -176,6 +176,15 @@ end
         ["wfs-lift"])) == ("wfs-lift",)
     @test Tuple(spec.name for spec in resolve_test_suites(
         ["calibration"])) == ("calibration-workflows",)
+    @test Tuple(spec.name for spec in resolve_test_suites(["pe01"])) == (
+        "prepared-execution-contracts",
+        "prepared-execution-interfaces",
+        "direct-imaging-batch",
+        "plant-reduced-order",
+        "wfs-zernike-curvature",
+        "plant-effective-command-routes",
+        "plant-path-input-publications",
+    )
     @test Tuple(spec.name for spec in resolve_test_suites(
         ["control"])) ==
         ("control-primitives", "control-reconstruction")
@@ -390,6 +399,14 @@ end
     ))
     @test registered_testset_paths() == normpath.(actual_testsets)
     @test registered_test_fixture_paths() == sort!(normpath.([
+        joinpath(
+            dirname(@__DIR__),
+            "backend_execution_context_conformance.jl",
+        ),
+        joinpath(
+            dirname(@__DIR__),
+            "calibration_interface_conformance.jl",
+        ),
         joinpath(dirname(@__DIR__), "detector_test_fixtures.jl"),
         joinpath(dirname(@__DIR__), "ka_cpu_style_fixture.jl"),
         joinpath(dirname(@__DIR__), "plant_device_batching_fixtures.jl"),
@@ -415,6 +432,14 @@ end
             dirname(@__DIR__),
             "prepared_execution_contract_helpers.jl",
         ),
+        joinpath(
+            dirname(@__DIR__),
+            "plant_acquisition_interface_conformance.jl",
+        ),
+        joinpath(
+            dirname(@__DIR__),
+            "wfs_four_pupil_interface_conformance.jl",
+        ),
         joinpath(dirname(@__DIR__), "wfs_stage_contract_fixtures.jl"),
     ]))
     fixture_users = Tuple(spec.name for spec in TEST_SUITE_SPECS
@@ -422,6 +447,7 @@ end
     @test fixture_users == (
         "ka-cpu",
         "prepared-execution-contracts",
+        "prepared-execution-interfaces",
         "direct-imaging-batch",
         "atmosphere-direction-batch",
         "plant-device-batching",

--- a/test/wfs_four_pupil_interface_conformance.jl
+++ b/test/wfs_four_pupil_interface_conformance.jl
@@ -1,0 +1,20 @@
+function assert_prepared_four_pupil_lgs_conformance!(
+    model::M,
+    intensity::AbstractMatrix{T},
+    scratch::AbstractMatrix{T},
+    fft_buffer::AbstractMatrix{Complex{T}},
+    fft_plan,
+    ifft_buffer::AbstractMatrix{Complex{T}},
+    ifft_plan,
+    target::Backends.AbstractComputeDevice,
+) where {M<:WavefrontSensors.AbstractPreparedFourPupilLGS,T<:AbstractFloat}
+    @test @inferred(
+        WavefrontSensors._require_exact_prepared_four_pupil_lgs_target(
+            model, target)) === nothing
+    result = @inferred WavefrontSensors.apply_prepared_four_pupil_lgs!(
+        model, intensity, scratch, fft_buffer, fft_plan, ifft_buffer,
+        ifft_plan)
+    @test result === intensity
+    @test all(isfinite, intensity)
+    return intensity
+end


### PR DESCRIPTION
Closes #229.

Tracker: #225  
Prerequisite: #228 (`5f4ddfd`)  
Next gate: #230 (PE-02)

## What changed

PE-01 audits all 17 prepared-execution interface candidates recorded by PE-00 and makes each disposition executable:

- Retains seven domain-owned nominal protocols with documented required methods, ownership, aliasing, exact-binding, failure, reentrancy, and backend semantics.
- Removes three role-only abstract roots that had no shared behavior:
  - `Optics.AbstractDirectImagingInputPlan`
  - `Plant._PreparedReducedOrderEventResponse`
  - `WavefrontSensors.AbstractPreparedCurvatureObservationMapping`
- Records five zero-size execution-selector families for terminology correction in PE-02.
- Defers two single-implementation erased Plant registry roots to the concrete family-group migration in PE-06.
- Adds reusable domain-owned conformance helpers and the bounded `pe01` test selector.
- Rejects calibration command storage that aliases DM coefficient storage before calibration mutation.
- Wires the prepared device-context conformance helper into optional CUDA and AMDGPU suites for PE-08 hardware requalification.

## Ownership and API impact

The retained interfaces are owned by `Calibration`, `WavefrontSensors`, `Backends`, and `Plant`; no universal plan root, `Interfaces` namespace, or generic `process!` API is introduced. Prepared-owner protocols state exact state/product/context binding and single-writer rules. Numerical plan protocols state caller-owned product/workspace and reentrancy rules.

There is no root export growth. The three removed roots were internal/private role markers; concrete callers now use closed concrete variants directly. No compatibility aliases or forwarding adapters are added.

The executable type inventory changes from 381 to 378 declarations. This PR introduces:

- direct `Memory` sites: +0
- stored `Any` sites: +0
- abstract/UnionAll hot storage sites: +0
- PE-06 erased registry sites: unchanged

## Validation

Local Julia 1.12.6 bounded gate:

```text
Pkg.test(test_args=["quality", "pe01", "calibration-workflows"])
```

Passed:

- quality registry checks and Aqua
- all 17 interface decisions and seven retained interface contracts
- every in-tree calibration, four-pupil LGS, host device-context, and acquisition-lifecycle implementation
- direct-imaging batch numerical/inference checks
- reduced-order numerical and allocation checks
- Zernike and Curvature WFS numerical checks
- effective-command and pupil-OPD route lifecycle, foreign-binding, inference, and warmed zero-allocation checks
- calibration workflow and alias-rejection checks

Additional affected detector lifecycle suites passed locally for global shutter, rolling shutter, frame transfer, up-the-ramp/avalanche snapshots, inference, and allocation. Multi-rate Plant composition passed with its one existing expected-broken test. Pyramid, BioEdge, and LGS suites also passed.

Representative prepared calls infer through concrete owners. Foreign acquisition states and aliased calibration command storage are rejected before mutation. Existing warmed CPU allocation contracts remain green. No numerical algorithm, detector/WFS physics, RTC transport, pacing, or declared hardware support changes in this PR.

Real CUDA and AMDGPU hardware requalification remains intentionally assigned to PE-08; their optional suites now invoke the shared execution-context conformance helper when run.
