### PR TITLE
Restore accelerator context type stability

### DIFF
--- a/ext/AdaptiveOpticsSimAMDGPUExt.jl
+++ b/ext/AdaptiveOpticsSimAMDGPUExt.jl
@@ -99,11 +99,12 @@ function Backends._with_compute_device(
     return AMDGPU.device!(f, _require_amdgpu_device(device))
 end
 
-struct AMDGPUPreparedDeviceExecutionContext <:
-    Backends._AbstractPreparedDeviceExecutionContext
+struct AMDGPUPreparedDeviceExecutionContext{
+    D<:Backends.AcceleratorComputeDevice{Backends.AMDGPUBackend},
+} <: Backends._AbstractPreparedDeviceExecutionContext
     device::AMDGPU.HIPDevice
     stream::AMDGPU.HIPStream
-    compute_device::Backends.AcceleratorComputeDevice
+    compute_device::D
 end
 
 function Backends._prepare_device_execution_context(

--- a/ext/AdaptiveOpticsSimCUDAExt.jl
+++ b/ext/AdaptiveOpticsSimCUDAExt.jl
@@ -80,11 +80,12 @@ function Backends._with_compute_device(
     return CUDA.device!(f, _require_cuda_device(device))
 end
 
-struct CUDAPreparedDeviceExecutionContext <:
-    Backends._AbstractPreparedDeviceExecutionContext
+struct CUDAPreparedDeviceExecutionContext{
+    D<:Backends.AcceleratorComputeDevice{Backends.CUDABackend},
+} <: Backends._AbstractPreparedDeviceExecutionContext
     device::CUDA.CuDevice
     stream::CUDA.CuStream
-    compute_device::Backends.AcceleratorComputeDevice
+    compute_device::D
 end
 
 function Backends._prepare_device_execution_context(

--- a/test/amdgpu/Project.toml
+++ b/test/amdgpu/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 AdaptiveOpticsSim = "002fb5eb-ad68-44a0-adbe-b299bfc2febc"
+FixedSizeArrays = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -13,5 +14,6 @@ AdaptiveOpticsSim = {path = "../.."}
 [compat]
 AMDGPU = "2.7"
 AdaptiveOpticsSim = "0.1"
+FixedSizeArrays = "1.3"
 KernelAbstractions = "0.9.42"
 julia = "1.12"

--- a/test/backend_optional_common.jl
+++ b/test/backend_optional_common.jl
@@ -3987,8 +3987,8 @@ function run_optional_plane_product_checks(tel::Telescope,
         GaussianDiskSourceModel(sigma_arcsec=T(0.02), n_side=5, T=T))
     extended = prepare_direct_imaging(wavefront,
         extended_source_asterism(extended_src); zero_padding=1)
-    @test extended.components isa Vector
-    @test extended.products isa Vector
+    @test extended.components isa FixedSizeVector
+    @test extended.products isa FixedSizeVector
     @test isconcretetype(eltype(extended.components))
     @test isconcretetype(eltype(extended.products))
     @test length(extended.components) == 25

--- a/test/cuda/Project.toml
+++ b/test/cuda/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AdaptiveOpticsSim = "002fb5eb-ad68-44a0-adbe-b299bfc2febc"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+FixedSizeArrays = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -13,5 +14,6 @@ AdaptiveOpticsSim = {path = "../.."}
 [compat]
 AdaptiveOpticsSim = "0.1"
 CUDA = "6"
+FixedSizeArrays = "1.3"
 KernelAbstractions = "0.9.42"
 julia = "1.12"

--- a/test/runtests_gpu_target_common.jl
+++ b/test/runtests_gpu_target_common.jl
@@ -12,6 +12,7 @@ using AdaptiveOpticsSim.Tomography
 using AdaptiveOpticsSim.Ensembles
 using AdaptiveOpticsSim: Plant
 using AdaptiveOpticsSim.Plant
+using FixedSizeArrays: FixedSizeVector
 using LinearAlgebra
 using Random
 using Statistics


### PR DESCRIPTION
Closes #253.

## Summary

- parameterize CUDA and AMDGPU prepared execution contexts by their exact backend-specific compute-device type
- preserve the existing `@inferred` execution-context contract instead of weakening it
- update extended direct-imaging hardware assertions to require fixed-membership `FixedSizeVector` storage

## Validation

- [x] `quality`
- [x] `core-optics`
- [x] `direct-science`
- [ ] complete WSL CUDA hardware target
- [ ] final pre-merge review
