### PR TITLE
CI-01: remove duplicate pull-request validation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,8 +56,21 @@ jobs:
       - name: Run bounded test shard with coverage
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(coverage=true, test_args=[ENV["ADAPTIVEOPTICS_TEST_SHARD"]])'
 
+      - name: Process shard coverage
+        uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: src,ext
+
+      - name: Upload shard coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-${{ matrix.shard }}
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 3
+
   project-coverage:
-    name: Project coverage / full composition
+    name: Transition baseline / full composition plus KA
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
@@ -95,10 +108,95 @@ jobs:
         with:
           directories: src,ext
 
-      - name: Upload project coverage to Codecov
+      - name: Upload transition baseline coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-transition-baseline
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 3
+
+  aggregate-coverage:
+    name: Aggregate project coverage
+    needs:
+      - shard-coverage
+      - project-coverage
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Require every coverage producer
+        env:
+          SHARD_RESULT: ${{ needs.shard-coverage.result }}
+          BASELINE_RESULT: ${{ needs.project-coverage.result }}
+        run: |
+          test "$SHARD_RESULT" = "success"
+          test "$BASELINE_RESULT" = "success"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download ci-foundations coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-ci-foundations
+          path: coverage/ci-foundations
+
+      - name: Download ci-sensors-control coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-ci-sensors-control
+          path: coverage/ci-sensors-control
+
+      - name: Download ci-plant-runtime coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-ci-plant-runtime
+          path: coverage/ci-plant-runtime
+
+      - name: Download ci-plant-optics coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-ci-plant-optics
+          path: coverage/ci-plant-optics
+
+      - name: Download transition baseline coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: adaptiveopticssim-coverage-transition-baseline
+          path: coverage/transition-baseline
+
+      - name: Validate coverage comparator
+        run: python3 test/ci/test_compare_lcov.py
+
+      - name: Compare shard union with transition baseline
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if test -n "$PR_BASE_SHA"; then
+            BASE_SHA="$PR_BASE_SHA"
+          else
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          python3 test/ci/compare_lcov.py \
+            --repo-root . \
+            --artifact-root coverage \
+            --base-sha "$BASE_SHA" \
+            --shard coverage/ci-foundations/lcov.info \
+            --shard coverage/ci-sensors-control/lcov.info \
+            --shard coverage/ci-plant-runtime/lcov.info \
+            --shard coverage/ci-plant-optics/lcov.info \
+            --baseline coverage/transition-baseline/lcov.info
+
+      - name: Upload aggregate project coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          files: lcov.info
+          files: coverage/ci-foundations/lcov.info,coverage/ci-sensors-control/lcov.info,coverage/ci-plant-runtime/lcov.info,coverage/ci-plant-optics/lcov.info
           disable_search: true
           fail_ci_if_error: true
           name: adaptiveopticssim-project

--- a/.github/workflows/cpu-validation.yml
+++ b/.github/workflows/cpu-validation.yml
@@ -20,8 +20,9 @@ jobs:
   full-composition:
     name: Full composition / Linux
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -263,7 +264,16 @@ jobs:
       - name: Verify backend-neutral package load
         run: julia --project=test/appleaccelerate --startup-file=no test/appleaccelerate/backend_neutral.jl
 
-      - name: Run full CPU suite with AppleAccelerate
+      - name: Run focused AppleAccelerate validation
+        if: github.event_name == 'pull_request'
+        env:
+          ADAPTIVEOPTICS_APPLE_FOCUSED_ONLY: "true"
+        run: julia --project=test/appleaccelerate --startup-file=no test/appleaccelerate/runtests.jl
+
+      - name: Run full Apple/root interaction with AppleAccelerate
+        if: >-
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch'
         run: julia --project=test/appleaccelerate --startup-file=no test/appleaccelerate/runtests.jl
 
       - name: Run Apple FFT coverage
@@ -273,6 +283,9 @@ jobs:
 
       - name: Instantiate Metal extension test environment
         run: julia --project=test/metal --startup-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.status()'
+
+      - name: Run Metal extension validation
+        run: julia --project=test/metal --startup-file=no test/metal/runtests.jl
 
       - name: Run Metal extension load coverage
         run: julia --project=test/metal --startup-file=no --code-coverage=user test/metal/runtests.jl

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,8 @@
-# The baseline-comparable full-composition plus focused KA CPU report and the
-# Apple platform extension report upload independently. Diagnostic shard
-# coverage runs do not upload partial reports because they change Julia's
-# attributed line universe.
+# The exact union of the four required Linux shard reports and the Apple
+# platform extension report upload independently. The aggregate workflow
+# fails closed unless every shard report is present and valid. During the
+# CI-01 transition it also requires, but does not upload, the full-plus-KA
+# baseline and verifies exact line-state equivalence before the core upload.
 #
 # Core source project and patch coverage are merge-blocking. Optional
 # extensions are target-specific, so their patch status is informational;

--- a/test/ci/compare_lcov.py
+++ b/test/ci/compare_lcov.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Compare the four authoritative shard LCOV reports with a transition baseline."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable, Mapping, Sequence
+
+
+class CoverageError(RuntimeError):
+    """Raised when coverage evidence is incomplete, malformed, or different."""
+
+
+LineKey = tuple[str, int]
+Coverage = dict[LineKey, bool]
+
+
+@dataclass(frozen=True)
+class CoverageTotals:
+    attributed: int
+    hit: int
+
+    @property
+    def missed(self) -> int:
+        return self.attributed - self.hit
+
+
+def _source_path(source: str, repo_root: Path, report: Path) -> str:
+    raw_path = Path(source)
+    absolute = raw_path if raw_path.is_absolute() else repo_root / raw_path
+    try:
+        relative = absolute.resolve().relative_to(repo_root)
+    except ValueError as error:
+        raise CoverageError(
+            f"{report}: source path is outside the repository: {source}"
+        ) from error
+    if not relative.parts or relative.parts[0] not in {"src", "ext"}:
+        raise CoverageError(
+            f"{report}: source path is outside src/ and ext/: {relative.as_posix()}"
+        )
+    return relative.as_posix()
+
+
+def parse_lcov(report: Path, repo_root: Path) -> Coverage:
+    """Parse attributed line hit/miss state from one nonempty LCOV report."""
+    report = report.resolve()
+    if not report.is_file():
+        raise CoverageError(f"missing LCOV report: {report}")
+    if report.stat().st_size == 0:
+        raise CoverageError(f"empty LCOV report: {report}")
+
+    coverage: Coverage = {}
+    source: str | None = None
+    record_lines: dict[int, bool] = {}
+    declared_lines: int | None = None
+    declared_hits: int | None = None
+    record_count = 0
+
+    def finish_record(line_number: int) -> None:
+        nonlocal source, record_lines, declared_lines, declared_hits, record_count
+        if source is None:
+            raise CoverageError(
+                f"{report}:{line_number}: end_of_record without an SF record"
+            )
+        if not record_lines:
+            if declared_lines not in {None, 0} or declared_hits not in {None, 0}:
+                raise CoverageError(
+                    f"{report}:{line_number}: {source} declares coverage for "
+                    "a record with no attributed DA lines"
+                )
+            source = None
+            record_lines = {}
+            declared_lines = None
+            declared_hits = None
+            record_count += 1
+            return
+        hits = sum(record_lines.values())
+        if declared_lines is not None and declared_lines != len(record_lines):
+            raise CoverageError(
+                f"{report}:{line_number}: LF={declared_lines} but parsed "
+                f"{len(record_lines)} DA lines for {source}"
+            )
+        if declared_hits is not None and declared_hits != hits:
+            raise CoverageError(
+                f"{report}:{line_number}: LH={declared_hits} but parsed "
+                f"{hits} hit lines for {source}"
+            )
+        for number, hit in record_lines.items():
+            key = (source, number)
+            coverage[key] = coverage.get(key, False) or hit
+        source = None
+        record_lines = {}
+        declared_lines = None
+        declared_hits = None
+        record_count += 1
+
+    try:
+        lines = report.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise CoverageError(f"{report}: LCOV report is not UTF-8") from error
+
+    for line_number, line in enumerate(lines, 1):
+        if line.startswith("SF:"):
+            if source is not None:
+                raise CoverageError(
+                    f"{report}:{line_number}: SF record started before end_of_record"
+                )
+            source_text = line[3:]
+            if not source_text:
+                raise CoverageError(f"{report}:{line_number}: empty SF path")
+            source = _source_path(source_text, repo_root, report)
+        elif line.startswith("DA:"):
+            if source is None:
+                raise CoverageError(f"{report}:{line_number}: DA outside an SF record")
+            fields = line[3:].split(",")
+            if len(fields) not in {2, 3}:
+                raise CoverageError(f"{report}:{line_number}: malformed DA record")
+            try:
+                number = int(fields[0])
+                count = int(fields[1])
+            except ValueError as error:
+                raise CoverageError(
+                    f"{report}:{line_number}: non-integer DA line or count"
+                ) from error
+            if number <= 0 or count < 0:
+                raise CoverageError(
+                    f"{report}:{line_number}: DA line must be positive and count nonnegative"
+                )
+            if number in record_lines:
+                raise CoverageError(
+                    f"{report}:{line_number}: duplicate DA line {number} for {source}"
+                )
+            record_lines[number] = count > 0
+        elif line.startswith("LF:"):
+            if source is None or declared_lines is not None:
+                raise CoverageError(f"{report}:{line_number}: misplaced or duplicate LF")
+            try:
+                declared_lines = int(line[3:])
+            except ValueError as error:
+                raise CoverageError(f"{report}:{line_number}: malformed LF") from error
+        elif line.startswith("LH:"):
+            if source is None or declared_hits is not None:
+                raise CoverageError(f"{report}:{line_number}: misplaced or duplicate LH")
+            try:
+                declared_hits = int(line[3:])
+            except ValueError as error:
+                raise CoverageError(f"{report}:{line_number}: malformed LH") from error
+        elif line == "end_of_record":
+            finish_record(line_number)
+        elif not line or line.startswith(
+            ("TN:", "FN:", "FNDA:", "FNF:", "FNH:", "BRDA:", "BRF:", "BRH:")
+        ):
+            continue
+        else:
+            raise CoverageError(f"{report}:{line_number}: unrecognized LCOV record: {line}")
+
+    if source is not None:
+        raise CoverageError(f"{report}: unterminated SF record for {source}")
+    if record_count == 0 or not coverage:
+        raise CoverageError(f"{report}: no attributed src/ or ext/ lines")
+    return coverage
+
+
+def union_coverage(reports: Iterable[Coverage]) -> Coverage:
+    combined: Coverage = {}
+    for report in reports:
+        for key, hit in report.items():
+            combined[key] = combined.get(key, False) or hit
+    return combined
+
+
+def changed_lines(repo_root: Path, base_sha: str) -> set[LineKey]:
+    """Return src line keys added or modified from base_sha through HEAD."""
+    command = [
+        "git",
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--unified=0",
+        "--no-color",
+        "--no-ext-diff",
+        "--diff-filter=ACMR",
+        f"{base_sha}...HEAD",
+        "--",
+        "src",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip()
+        raise CoverageError(f"cannot diff supplied base SHA {base_sha}: {detail}") from error
+
+    changed: set[LineKey] = set()
+    current_path: str | None = None
+    hunk_pattern = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ "):
+            path = line[4:]
+            current_path = None if path == "/dev/null" else path.removeprefix("b/")
+            if current_path is not None and not current_path.startswith("src/"):
+                raise CoverageError(f"git diff returned an unexpected path: {current_path}")
+        elif line.startswith("@@ "):
+            if current_path is None:
+                continue
+            match = hunk_pattern.match(line)
+            if match is None:
+                raise CoverageError(f"cannot parse git diff hunk: {line}")
+            start = int(match.group(1))
+            count = int(match.group(2) or "1")
+            changed.update((current_path, number) for number in range(start, start + count))
+    return changed
+
+
+def coverage_totals(coverage: Mapping[LineKey, bool], keys: set[LineKey] | None = None) -> CoverageTotals:
+    selected = coverage.keys() if keys is None else coverage.keys() & keys
+    states = [coverage[key] for key in selected]
+    return CoverageTotals(len(states), sum(states))
+
+
+def _format_totals(label: str, totals: CoverageTotals) -> str:
+    percent = "n/a" if totals.attributed == 0 else f"{100 * totals.hit / totals.attributed:.3f}%"
+    return (
+        f"{label}: attributed={totals.attributed}, hit={totals.hit}, "
+        f"missed={totals.missed}, coverage={percent}"
+    )
+
+
+def _format_keys(keys: Iterable[LineKey], limit: int = 20) -> str:
+    ordered = sorted(keys)
+    rendered = [f"{path}:{line}" for path, line in ordered[:limit]]
+    if len(ordered) > limit:
+        rendered.append(f"... and {len(ordered) - limit} more")
+    return ", ".join(rendered) or "none"
+
+
+def validate_artifact_tree(artifact_root: Path, expected_reports: Sequence[Path]) -> None:
+    artifact_root = artifact_root.resolve()
+    if not artifact_root.is_dir():
+        raise CoverageError(f"missing coverage artifact directory: {artifact_root}")
+    expected = {path.resolve() for path in expected_reports}
+    if len(expected) != len(expected_reports):
+        raise CoverageError("coverage report paths must be distinct")
+    actual = {path.resolve() for path in artifact_root.rglob("*") if path.is_file()}
+    missing = expected - actual
+    extra = actual - expected
+    if missing or extra:
+        raise CoverageError(
+            "coverage artifact tree does not contain exactly the expected reports; "
+            f"missing={_format_keys((str(path), 0) for path in missing)}, "
+            f"extra={_format_keys((str(path), 0) for path in extra)}"
+        )
+
+
+def compare_reports(
+    repo_root: Path,
+    artifact_root: Path,
+    shard_paths: Sequence[Path],
+    baseline_path: Path,
+    base_sha: str,
+) -> tuple[CoverageTotals, CoverageTotals]:
+    if len(shard_paths) != 4:
+        raise CoverageError(f"expected exactly four shard reports, received {len(shard_paths)}")
+    reports = [*shard_paths, baseline_path]
+    validate_artifact_tree(artifact_root, reports)
+    shard_union = union_coverage(parse_lcov(path, repo_root) for path in shard_paths)
+    baseline = parse_lcov(baseline_path, repo_root)
+    changed = changed_lines(repo_root, base_sha)
+    shard_core_keys = {key for key in shard_union if key[0].startswith("src/")}
+    baseline_core_keys = {key for key in baseline if key[0].startswith("src/")}
+
+    missing_keys = baseline.keys() - shard_union.keys()
+    extra_keys = shard_union.keys() - baseline.keys()
+    state_differences = {
+        key for key in baseline.keys() & shard_union.keys()
+        if baseline[key] != shard_union[key]
+    }
+    shard_project = coverage_totals(shard_union, shard_core_keys)
+    baseline_project = coverage_totals(baseline, baseline_core_keys)
+    shard_patch = coverage_totals(shard_union, changed)
+    baseline_patch = coverage_totals(baseline, changed)
+
+    print(_format_totals("shard project", shard_project))
+    print(_format_totals("baseline project", baseline_project))
+    print(_format_totals("shard patch", shard_patch))
+    print(_format_totals("baseline patch", baseline_patch))
+
+    if missing_keys or extra_keys or state_differences:
+        raise CoverageError(
+            "shard coverage differs from the transition baseline; "
+            f"missing lines: {_format_keys(missing_keys)}; "
+            f"extra lines: {_format_keys(extra_keys)}; "
+            f"hit/miss differences: {_format_keys(state_differences)}"
+        )
+    if shard_project != baseline_project or shard_patch != baseline_patch:
+        raise CoverageError("project or patch totals differ from the transition baseline")
+    return shard_project, shard_patch
+
+
+def _arguments(arguments: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--shard", action="append", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path, required=True)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    args = _arguments(arguments)
+    try:
+        compare_reports(
+            args.repo_root.resolve(),
+            args.artifact_root,
+            args.shard,
+            args.baseline,
+            args.base_sha,
+        )
+    except CoverageError as error:
+        print(f"coverage comparison failed: {error}", file=sys.stderr)
+        return 1
+    print("coverage comparison passed: shard and baseline line evidence are identical")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/ci/test_compare_lcov.py
+++ b/test/ci/test_compare_lcov.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("compare_lcov.py")
+SPEC = importlib.util.spec_from_file_location("compare_lcov", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+compare_lcov = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = compare_lcov
+SPEC.loader.exec_module(compare_lcov)
+
+
+def write_lcov(path: Path, records: dict[str, dict[int, int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    for source, counts in records.items():
+        lines.append(f"SF:{source}")
+        lines.extend(f"DA:{line},{count}" for line, count in counts.items())
+        lines.append(f"LF:{len(counts)}")
+        lines.append(f"LH:{sum(count > 0 for count in counts.values())}")
+        lines.append("end_of_record")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class CompareLcovTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        (self.root / "src").mkdir()
+        (self.root / "ext").mkdir()
+        (self.root / "src" / "core.jl").write_text("a\nb\nc\n", encoding="utf-8")
+        (self.root / "ext" / "gpu.jl").write_text("x\ny\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        subprocess.run(["git", "config", "user.email", "ci@example.invalid"], cwd=self.root, check=True)
+        subprocess.run(["git", "config", "user.name", "CI Test"], cwd=self.root, check=True)
+        subprocess.run(["git", "add", "src", "ext"], cwd=self.root, check=True)
+        subprocess.run(["git", "commit", "-qm", "baseline"], cwd=self.root, check=True)
+        self.base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=self.root, check=True,
+            capture_output=True, text=True,
+        ).stdout.strip()
+        (self.root / "src" / "core.jl").write_text("a\nchanged\nc\n", encoding="utf-8")
+        subprocess.run(["git", "add", "src/core.jl"], cwd=self.root, check=True)
+        subprocess.run(["git", "commit", "-qm", "change"], cwd=self.root, check=True)
+        self.artifacts = self.root / "coverage"
+        self.shards = [self.artifacts / f"shard-{index}" / "lcov.info" for index in range(4)]
+        self.baseline = self.artifacts / "baseline" / "lcov.info"
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def write_equivalent_reports(self) -> None:
+        write_lcov(self.shards[0], {"src/core.jl": {1: 1, 2: 0}})
+        write_lcov(self.shards[1], {"src/core.jl": {2: 2, 3: 0}})
+        write_lcov(self.shards[2], {"ext/gpu.jl": {1: 0}})
+        write_lcov(self.shards[3], {"ext/gpu.jl": {2: 3}})
+        write_lcov(self.baseline, {
+            "src/core.jl": {1: 4, 2: 1, 3: 0},
+            "ext/gpu.jl": {1: 0, 2: 1},
+        })
+
+    def test_equivalent_union_and_patch_totals_pass(self) -> None:
+        self.write_equivalent_reports()
+        project, patch = compare_lcov.compare_reports(
+            self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+        )
+        self.assertEqual(project, compare_lcov.CoverageTotals(3, 2))
+        self.assertEqual(patch, compare_lcov.CoverageTotals(1, 1))
+
+    def test_hit_miss_difference_fails(self) -> None:
+        self.write_equivalent_reports()
+        write_lcov(self.shards[1], {"src/core.jl": {2: 0, 3: 0}})
+        with self.assertRaisesRegex(compare_lcov.CoverageError, "hit/miss differences"):
+            compare_lcov.compare_reports(
+                self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+            )
+
+    def test_extra_artifact_file_fails_closed(self) -> None:
+        self.write_equivalent_reports()
+        (self.artifacts / "unexpected.txt").write_text("unexpected", encoding="utf-8")
+        with self.assertRaisesRegex(compare_lcov.CoverageError, "exactly the expected"):
+            compare_lcov.compare_reports(
+                self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+            )
+
+    def test_missing_artifact_fails_closed(self) -> None:
+        self.write_equivalent_reports()
+        self.shards[3].unlink()
+        with self.assertRaisesRegex(compare_lcov.CoverageError, "exactly the expected"):
+            compare_lcov.compare_reports(
+                self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+            )
+
+    def test_empty_report_fails_closed(self) -> None:
+        self.write_equivalent_reports()
+        self.shards[0].write_text("", encoding="utf-8")
+        with self.assertRaisesRegex(compare_lcov.CoverageError, "empty LCOV report"):
+            compare_lcov.compare_reports(
+                self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+            )
+
+    def test_zero_line_source_record_is_ignored(self) -> None:
+        self.write_equivalent_reports()
+        existing = self.shards[0].read_text(encoding="utf-8")
+        self.shards[0].write_text(
+            "SF:src/empty.jl\nLF:0\nLH:0\nend_of_record\n" + existing,
+            encoding="utf-8",
+        )
+        project, patch = compare_lcov.compare_reports(
+            self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+        )
+        self.assertEqual(project, compare_lcov.CoverageTotals(3, 2))
+        self.assertEqual(patch, compare_lcov.CoverageTotals(1, 1))
+
+    def test_extension_change_does_not_enter_core_patch_totals(self) -> None:
+        self.write_equivalent_reports()
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=self.root, check=True,
+            capture_output=True, text=True,
+        ).stdout.strip()
+        (self.root / "ext" / "gpu.jl").write_text("changed\ny\n", encoding="utf-8")
+        subprocess.run(["git", "add", "ext/gpu.jl"], cwd=self.root, check=True)
+        subprocess.run(["git", "commit", "-qm", "extension change"], cwd=self.root, check=True)
+        project, patch = compare_lcov.compare_reports(
+            self.root, self.artifacts, self.shards, self.baseline, base_sha
+        )
+        self.assertEqual(project, compare_lcov.CoverageTotals(3, 2))
+        self.assertEqual(patch, compare_lcov.CoverageTotals(0, 0))
+
+    def test_malformed_report_fails_closed(self) -> None:
+        self.write_equivalent_reports()
+        self.shards[0].write_text("SF:src/core.jl\nDA:not-a-line,1\n", encoding="utf-8")
+        with self.assertRaisesRegex(compare_lcov.CoverageError, "non-integer DA"):
+            compare_lcov.compare_reports(
+                self.root, self.artifacts, self.shards, self.baseline, self.base_sha
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #290
Parent: #289

## What changed

- removes the duplicate full Linux composition run from pull-request cadence while retaining it on main, nightly, and manual runs
- makes the four existing Linux coverage shards authoritative producers for one fail-closed aggregate Codecov upload
- keeps a temporary, non-uploaded monolithic coverage baseline and compares exact `src/`/`ext/` line state plus core project/patch totals
- narrows Apple pull-request validation to the focused AppleAccelerate surface while retaining full Apple/root interaction nightly and manually
- preserves uninstrumented and instrumented Metal checks

## Why

Ready pull requests currently repeat the complete test suite across full, sharded, coverage, and Apple jobs. The suite content is useful; the duplicated orchestration is what drives 26–40 minute feedback.

This transition head intentionally retains one final monolithic coverage run. Once CI proves the shard union is identical, a follow-up commit in this PR will remove that temporary producer and comparator from pull-request cadence.

## Validation

- independent design and exact-diff review completed
- LCOV comparator tests: 8/8 passed
- 82 registered Julia suites map exactly once across four CI shards
- workflow and Codecov YAML parsed successfully
- `git diff --check` passed

No simulation runtime code, test assertions, numerical tolerances, accelerator test contents, or coverage thresholds changed.
