### PR TITLE
Make billed validation manual-only

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,6 @@
 name: Coverage
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
-  schedule:
-    - cron: "47 10 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cpu-validation.yml
+++ b/.github/workflows/cpu-validation.yml
@@ -1,12 +1,6 @@
 name: CPU Validation
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
-  schedule:
-    - cron: "17 9 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,25 @@
 #   replaceable workspace scratch.
 # - Compare outputs against OOPAO reference datasets within tolerance.
 #
+# Validation and GitHub Actions cost:
+# - Validate locally first. Use the local CPU/AMDGPU host, `ssh wsl` for CUDA
+#   validation, and `ssh raspberrypi` for Linux aarch64 validation when those
+#   targets are relevant and available.
+# - Run the smallest selector that covers the changed ownership and dependency
+#   surface. Run the complete suite locally only for cross-cutting changes or a
+#   final release/milestone gate.
+# - Do not push commits merely to exercise GitHub Actions, and do not rerun an
+#   unchanged failed workflow as a debugging strategy. Reproduce and repair
+#   locally before publishing a new exact head.
+# - Keep scheduled exhaustive GitHub workflows disabled. GitHub-hosted
+#   platform, coverage, and full-composition matrices are manual final gates,
+#   not per-commit or nightly development loops.
+# - Use at most one justified exact-head GitHub validation run for a PR after
+#   local review. Additional billed runs require a concrete platform-only
+#   question that cannot be answered on the available local targets.
+# - Record local commands, target versions, and results in the PR so local
+#   evidence remains reviewable when GitHub Actions is intentionally not run.
+#
 # Dependencies:
 # - Keep core dependencies minimal.
 # - Optional features (I/O helpers, ModelingToolkit control, plotting extras)


### PR DESCRIPTION
Closes #294

## What changed

- removes automatic pull-request, push, and daily schedule triggers from CPU Validation and Coverage
- retains both workflows as explicit `workflow_dispatch` gates
- records a local-first validation and GitHub Actions cost policy in `AGENTS.md`

## Why

The repository accumulated approximately $333.77 of GitHub Actions usage. Exhaustive CPU, coverage, macOS, Windows, and Apple jobs were running both on development heads and every day without code changes. Validation should use the available local CPU/AMDGPU host, WSL CUDA host, and Raspberry Pi aarch64 host first; billed Actions should be a deliberate final exception.

## Local validation

- workflow YAML parsed successfully
- both changed workflows expose only `workflow_dispatch`
- `git diff --check` passed
- no package runtime or test contents changed
- CPU Validation and Coverage were disabled before this branch was pushed; branch push triggered zero Actions runs

The workflows should be re-enabled only after this PR is merged, at which point their committed triggers are manual-only.
