### PR TITLE
Add local impact-based validation planning

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,59 +4,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  shard-coverage:
-    name: Shard coverage / ${{ matrix.shard }}
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        shard:
-          - ci-foundations
-          - ci-sensors-control
-          - ci-plant-runtime
-          - ci-plant-optics
-    env:
-      ADAPTIVEOPTICS_TEST_COVERAGE: "true"
-      ADAPTIVEOPTICS_TEST_SHARD: ${{ matrix.shard }}
-      JULIA_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
-        with:
-          version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
-      - name: Instantiate
-        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
-
-      - name: Run bounded test shard with coverage
-        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(coverage=true, test_args=[ENV["ADAPTIVEOPTICS_TEST_SHARD"]])'
-
   project-coverage:
-    name: Project coverage / full composition
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
+    name: Full project coverage
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -66,31 +23,19 @@ jobs:
       OMP_NUM_THREADS: "1"
       MKL_NUM_THREADS: "1"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
+      - uses: julia-actions/cache@v3
       - name: Instantiate
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
-
       - name: Run full composition with coverage
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(coverage=true)'
-
-      - name: Run KA CPU matrix with coverage
-        run: julia --project=. --startup-file=no --code-coverage=user test/ka_cpu_runtests.jl
-
-      - name: Process project Julia coverage
+      - name: Process Julia coverage
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,ext
-
       - name: Upload project coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/cpu-validation.yml
+++ b/.github/workflows/cpu-validation.yml
@@ -2,285 +2,211 @@ name: CPU Validation
 
 on:
   workflow_dispatch:
+    inputs:
+      gate:
+        description: Validation gate to run
+        required: true
+        default: linux-selector
+        type: choice
+        options:
+          - linux-selector
+          - linux-full
+          - macos-selector
+          - windows-selector
+          - linux-aarch64
+          - grouped-cpu
+          - scheduler
+          - appleaccelerate
+          - metal
+      selectors:
+        description: Comma-separated test selectors used by selector gates
+        required: true
+        default: quality
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
-jobs:
-  full-composition:
-    name: Full composition / Linux
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    env:
-      JULIA_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+env:
+  JULIA_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  OMP_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
 
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
+jobs:
+  linux-selector:
+    name: Linux / selected tests
+    if: inputs.gate == 'linux-selector'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      ADAPTIVEOPTICS_TEST_SELECTORS: ${{ inputs.selectors }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
+      - uses: julia-actions/cache@v3
       - name: Instantiate
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+      - name: Run selected tests
+        run: julia --project=. --startup-file=no test/ci/run_selected_tests.jl
 
+  linux-full:
+    name: Linux / full composition
+    if: inputs.gate == 'linux-full'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v3
+      - name: Instantiate
+        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
       - name: Run full test suite
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
 
-  fast-feedback:
-    name: Fast feedback / ${{ matrix.shard }}
-    if: >-
-      github.event_name != 'push' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        shard:
-          - ci-foundations
-          - ci-sensors-control
-          - ci-plant-runtime
-          - ci-plant-optics
-    env:
-      ADAPTIVEOPTICS_TEST_SHARD: ${{ matrix.shard }}
-      JULIA_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
-        with:
-          version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
-      - name: Instantiate
-        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
-
-      - name: Run bounded Linux shard
-        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(test_args=[ENV["ADAPTIVEOPTICS_TEST_SHARD"]])'
-
-  platform-closure:
-    name: Platform closure / ${{ matrix.os }} / ${{ matrix.shard }}
-    if: >-
-      github.event_name != 'push' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false)
-    runs-on: ${{ matrix.os }}
+  macos-selector:
+    name: macOS / selected tests
+    if: inputs.gate == 'macos-selector'
+    runs-on: macos-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - windows-latest
-        shard:
-          - ci-foundations
-          - ci-sensors-control
-          - ci-plant-runtime
-          - ci-plant-optics
     env:
-      ADAPTIVEOPTICS_TEST_SHARD: ${{ matrix.shard }}
-      JULIA_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
+      ADAPTIVEOPTICS_TEST_SELECTORS: ${{ inputs.selectors }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
+      - uses: julia-actions/cache@v3
       - name: Instantiate
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+      - name: Run selected tests
+        run: julia --project=. --startup-file=no test/ci/run_selected_tests.jl
 
-      - name: Run cross-platform closure shard
-        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(test_args=[ENV["ADAPTIVEOPTICS_TEST_SHARD"]])'
-
-  grouped-cpu-execution:
-    name: Grouped CPU execution
-    if: >-
-      github.event_name != 'push' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+  windows-selector:
+    name: Windows / selected tests
+    if: inputs.gate == 'windows-selector'
+    runs-on: windows-latest
+    timeout-minutes: 60
     env:
-      JULIA_NUM_THREADS: "4"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
+      ADAPTIVEOPTICS_TEST_SELECTORS: ${{ inputs.selectors }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
+      - uses: julia-actions/cache@v3
       - name: Instantiate
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+      - name: Run selected tests
+        run: julia --project=. --startup-file=no test/ci/run_selected_tests.jl
 
-      - name: Run Gate 6 grouped CPU tests
-        run: julia --threads=4 --project=. --startup-file=no -e 'using Pkg; Pkg.test(test_args=["gate6"])'
-
-  scheduler-extensions:
-    name: Optional CPU scheduler extensions
-    if: >-
-      github.event_name != 'push' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      JULIA_NUM_THREADS: "4"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
-        with:
-          version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
-      - name: Instantiate scheduler test environment
-        run: julia --project=test/schedulers --startup-file=no -e 'using Pkg; Pkg.instantiate()'
-
-      - name: Run scheduler extension tests
-        run: julia --threads=4 --project=test/schedulers --startup-file=no test/schedulers/runtests.jl
-
-  linux-arm64-portability:
-    name: Linux aarch64 portability
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch'
+  linux-aarch64:
+    name: Linux aarch64 / selected tests
+    if: inputs.gate == 'linux-aarch64'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     env:
-      JULIA_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
+      ADAPTIVEOPTICS_TEST_SELECTORS: ${{ inputs.selectors }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
-
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
-
+      - uses: julia-actions/cache@v3
       - name: Verify Linux aarch64 runner
-        run: julia --startup-file=no -e 'using InteractiveUtils; Sys.islinux() && Sys.ARCH === :aarch64 || error("Linux aarch64 validation requires an aarch64 runner"); versioninfo()'
-
+        run: >-
+          julia --startup-file=no -e
+          'using InteractiveUtils;
+          Sys.islinux() && Sys.ARCH === :aarch64 || error("expected Linux aarch64");
+          versioninfo()'
       - name: Instantiate
         run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+      - name: Run selected tests
+        run: julia --project=. --startup-file=no test/ci/run_selected_tests.jl
 
-      - name: Run Linux aarch64 portability shard
-        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(test_args=["ci-foundations"])'
-
-  apple-accelerate:
-    name: Apple Silicon / AppleAccelerate
-    if: >-
-      github.event_name != 'push' &&
-      (github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false)
-    runs-on: macos-15
-    timeout-minutes: 90
-    permissions:
-      contents: read
-      id-token: write
+  grouped-cpu:
+    name: Grouped CPU execution
+    if: inputs.gate == 'grouped-cpu'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
-      JULIA_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      OMP_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-      VECLIB_MAXIMUM_THREADS: "1"
+      JULIA_NUM_THREADS: "4"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
+      - uses: julia-actions/cache@v3
+      - name: Instantiate
+        run: julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+      - name: Run grouped CPU tests
+        run: julia --threads=4 --project=. --startup-file=no -e 'using Pkg; Pkg.test(test_args=["gate6"])'
 
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v3
+  scheduler:
+    name: Optional CPU scheduler extensions
+    if: inputs.gate == 'scheduler'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      JULIA_NUM_THREADS: "4"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v3
+      - name: Instantiate scheduler environment
+        run: julia --project=test/schedulers --startup-file=no -e 'using Pkg; Pkg.instantiate()'
+      - name: Run scheduler extension tests
+        run: julia --threads=4 --project=test/schedulers --startup-file=no test/schedulers/runtests.jl
 
+  appleaccelerate:
+    name: Apple Silicon / AppleAccelerate
+    if: inputs.gate == 'appleaccelerate'
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      VECLIB_MAXIMUM_THREADS: "1"
+      ADAPTIVEOPTICS_APPLE_FOCUSED_ONLY: "true"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v3
       - name: Verify Apple Silicon runner
-        run: julia --startup-file=no -e 'using InteractiveUtils; Sys.isapple() && Sys.ARCH === :aarch64 || error("AppleAccelerate validation requires Apple Silicon"); versioninfo()'
-
-      - name: Instantiate AppleAccelerate test environment
+        run: >-
+          julia --startup-file=no -e
+          'using InteractiveUtils;
+          Sys.isapple() && Sys.ARCH === :aarch64 || error("expected Apple Silicon");
+          versioninfo()'
+      - name: Instantiate AppleAccelerate environment
         run: julia --project=test/appleaccelerate --startup-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.status()'
-
       - name: Verify backend-neutral package load
         run: julia --project=test/appleaccelerate --startup-file=no test/appleaccelerate/backend_neutral.jl
-
-      - name: Run full CPU suite with AppleAccelerate
+      - name: Run focused AppleAccelerate validation
         run: julia --project=test/appleaccelerate --startup-file=no test/appleaccelerate/runtests.jl
 
-      - name: Run Apple FFT coverage
-        env:
-          ADAPTIVEOPTICS_APPLE_FOCUSED_ONLY: "true"
-        run: julia --project=test/appleaccelerate --startup-file=no --code-coverage=user test/appleaccelerate/runtests.jl
-
-      - name: Instantiate Metal extension test environment
+  metal:
+    name: Apple Silicon / Metal extension
+    if: inputs.gate == 'metal'
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v3
+      - name: Instantiate Metal environment
         run: julia --project=test/metal --startup-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.status()'
-
-      - name: Run Metal extension load coverage
-        run: julia --project=test/metal --startup-file=no --code-coverage=user test/metal/runtests.jl
-
-      - name: Process Apple platform extension coverage
-        uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: ext
-
-      - name: Upload Apple platform extension coverage to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          disable_search: true
-          fail_ci_if_error: true
-          name: adaptiveopticssim-apple-platform
-          use_oidc: true
+      - name: Run Metal extension validation
+        run: julia --project=test/metal --startup-file=no test/metal/runtests.jl

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,16 @@
-# The baseline-comparable full-composition plus focused KA CPU report and the
-# Apple platform extension report upload independently. Diagnostic shard
-# coverage runs do not upload partial reports because they change Julia's
-# attributed line universe.
+# Full project coverage is an explicit manual gate and produces the one
+# authoritative upload. Optional CUDA and AMDGPU extension reports may augment
+# a commit when their self-hosted manual workflows are requested separately.
 #
 # Core source project and patch coverage are merge-blocking. Optional
 # extensions are target-specific, so their patch status is informational;
 # native hardware validation is the authoritative extension gate.
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 1
 
 comment:
-  after_n_builds: 2
+  after_n_builds: 1
 
 coverage:
   status:

--- a/test/ci/impact_planner.jl
+++ b/test/ci/impact_planner.jl
@@ -1,0 +1,521 @@
+#!/usr/bin/env julia
+
+include(joinpath(@__DIR__, "..", "test_selection.jl"))
+
+@enum AcceleratorScope begin
+    NoAccelerator
+    DetectorAccelerator
+    FullAccelerator
+end
+
+mutable struct ValidationPlan
+    selectors::Set{String}
+    run_cpu::Bool
+    run_cuda::Bool
+    run_amdgpu::Bool
+    accelerator_scope::AcceleratorScope
+    run_aarch64::Bool
+    run_grouped_cpu::Bool
+    run_scheduler::Bool
+    manual_gates::Set{String}
+end
+
+ValidationPlan() = ValidationPlan(
+    Set{String}(), false, false, false, NoAccelerator,
+    false, false, false, Set{String}())
+
+const CLOSURE_SELECTORS = Tuple(first.(TEST_CI_SHARD_SPECS))
+const REGISTERED_SELECTORS = Set((test_suite_names()..., test_group_names()...))
+const SELECTOR_ORDER = (test_suite_names()..., test_group_names()...)
+
+const DETECTOR_SHARED_SELECTORS = (
+    "detector-parameter-ownership",
+    "prepared-detector-ownership",
+    "detector-shared",
+    "detector-lifecycle",
+    "detector-response",
+    "detector-shared-qualification",
+    "detector-thermal",
+    "detector-artifacts",
+    "plant-detector-transitions",
+    "plant-device-model-matrix",
+)
+
+const DETECTOR_FILE_SELECTORS = Dict(
+    "ccd.jl" => ("detector-ccd", "detector-skipper"),
+    "cmos.jl" => ("detector-cmos",),
+    "emccd.jl" => ("detector-emccd",),
+    "hgcdte.jl" => ("detector-hgcdte",),
+    "hgcdte_avalanche_array.jl" => ("detector-hgcdte-avalanche",),
+    "ingaas.jl" => ("detector-ingaas",),
+    "linear_apd.jl" => ("detector-linear-apd",),
+    "mkid_array.jl" => ("detector-mkid",),
+    "spad_array.jl" => ("detector-spad",),
+)
+
+const WFS_SELECTORS = (
+    "wfs-acquisition-ownership",
+    "wfs-common",
+    "wfs-shack-hartmann",
+    "wfs-pyramid-bi-o-edge",
+    "wfs-zernike-curvature",
+    "wfs-lift",
+)
+
+const GPU_RELEVANT_SUITES = Set((
+    "ka-cpu",
+    "backend-smoke",
+    "direct-imaging-batch",
+    "atmosphere-direction-batch",
+    "plant-device-batching",
+    "plant-device-model-matrix",
+    WFS_SELECTORS...,
+    DETECTOR_TEST_SUITE_NAMES...,
+))
+
+const DETECTOR_GPU_SUITES = Set(DETECTOR_TEST_SUITE_NAMES)
+
+function registered_test_path_selectors()
+    result = Dict{String,Set{String}}()
+    for spec in TEST_SUITE_SPECS, path in (spec.paths..., spec.fixtures...)
+        repository_path = replace(joinpath("test", path), '\\' => '/')
+        push!(get!(Set{String}, result, repository_path), spec.name)
+    end
+    return result
+end
+
+const REGISTERED_TEST_PATH_SELECTORS = registered_test_path_selectors()
+
+function normalized_repository_path(path::AbstractString)
+    normalized = replace(normpath(String(path)), '\\' => '/')
+    startswith(normalized, "./") && (normalized = normalized[3:end])
+    (isempty(normalized) || isabspath(normalized) || normalized == ".." ||
+        startswith(normalized, "../")) && throw(ArgumentError(
+            "expected a repository-relative path, got '$path'"))
+    return normalized
+end
+
+function add_selectors!(plan::ValidationPlan, selectors)
+    for selector in selectors
+        selector in REGISTERED_SELECTORS || error(
+            "unknown test selector '$selector' in validation policy")
+        push!(plan.selectors, selector)
+    end
+    plan.run_cpu = true
+    return plan
+end
+
+function widen_accelerator_scope!(plan::ValidationPlan, scope::AcceleratorScope)
+    Int(scope) > Int(plan.accelerator_scope) && (plan.accelerator_scope = scope)
+    return plan
+end
+
+function request_cuda!(plan::ValidationPlan, scope::AcceleratorScope)
+    plan.run_cuda = true
+    return widen_accelerator_scope!(plan, scope)
+end
+
+function request_amdgpu!(plan::ValidationPlan, scope::AcceleratorScope)
+    plan.run_amdgpu = true
+    return widen_accelerator_scope!(plan, scope)
+end
+
+function request_accelerators!(plan::ValidationPlan, scope::AcceleratorScope)
+    request_cuda!(plan, scope)
+    request_amdgpu!(plan, scope)
+    return plan
+end
+
+function all_validation!(plan::ValidationPlan)
+    add_selectors!(plan, CLOSURE_SELECTORS)
+    request_accelerators!(plan, FullAccelerator)
+    plan.run_aarch64 = true
+    plan.run_grouped_cpu = true
+    plan.run_scheduler = true
+    union!(plan.manual_gates, (
+        "macos-selector", "windows-selector", "appleaccelerate",
+        "metal", "coverage"))
+    return plan
+end
+
+function add_registered_test_impacts!(plan::ValidationPlan, path::String)
+    selectors = get(REGISTERED_TEST_PATH_SELECTORS, path, nothing)
+    selectors === nothing && return false
+    add_selectors!(plan, selectors)
+    if !isempty(intersect(selectors, GPU_RELEVANT_SUITES))
+        scope = issubset(selectors, DETECTOR_GPU_SUITES) ?
+            DetectorAccelerator : FullAccelerator
+        request_accelerators!(plan, scope)
+    end
+    if !isempty(intersect(selectors, Set((
+            "plant-topology-growth", "plant-event-composition",
+            "plant-cpu-execution"))))
+        plan.run_grouped_cpu = true
+    end
+    return true
+end
+
+function add_detector_impacts!(plan::ValidationPlan, path::String)
+    family = get(DETECTOR_FILE_SELECTORS, basename(path), nothing)
+    family === nothing ?
+        add_selectors!(plan, ("detectors", "plant-detector-transitions",
+            "plant-device-model-matrix")) :
+        add_selectors!(plan, (DETECTOR_SHARED_SELECTORS..., family...))
+    request_accelerators!(plan, DetectorAccelerator)
+    return plan
+end
+
+function add_wfs_impacts!(plan::ValidationPlan, path::String)
+    selectors = if occursin("shack_hartmann", path)
+        ("wfs-acquisition-ownership", "wfs-common", "wfs-shack-hartmann")
+    elseif occursin("pyramid", path) || occursin("bi_o_edge", path) ||
+            occursin("bioedge", path) || occursin("focal_plane_modulation", path)
+        ("wfs-acquisition-ownership", "wfs-common", "wfs-pyramid-bi-o-edge")
+    elseif occursin("zernike", path) || occursin("curvature", path)
+        ("wfs-acquisition-ownership", "wfs-common", "wfs-zernike-curvature")
+    elseif occursin("lift", path)
+        ("wfs-acquisition-ownership", "wfs-common", "wfs-lift")
+    else
+        WFS_SELECTORS
+    end
+    add_selectors!(plan, selectors)
+    request_accelerators!(plan, FullAccelerator)
+    return plan
+end
+
+function add_plant_impacts!(plan::ValidationPlan, path::String)
+    stem = first(splitext(basename(path)))
+    candidate = "plant-" * replace(stem, '_' => '-')
+    if candidate in REGISTERED_SELECTORS
+        add_selectors!(plan, (candidate, "prepared-execution-contracts"))
+    else
+        add_selectors!(plan, ("ci-plant-runtime", "ci-plant-optics"))
+    end
+    if any(fragment -> occursin(fragment, stem), (
+            "preparation", "resource", "partition", "device", "target",
+            "sampled", "direct_measurement", "path_input"))
+        request_accelerators!(plan, FullAccelerator)
+    end
+    if any(fragment -> occursin(fragment, stem), (
+            "cpu_execution", "device_batching", "mixed_serial",
+            "topology_growth"))
+        plan.run_grouped_cpu = true
+    end
+    return plan
+end
+
+function add_source_impacts!(plan::ValidationPlan, path::String)
+    startswith(path, "src/") || return false
+    if path in ("src/AdaptiveOpticsSim.jl", "src/exports.jl") ||
+            startswith(path, "src/core/") || startswith(path, "src/backends/")
+        all_validation!(plan)
+    elseif startswith(path, "src/detectors/")
+        add_detector_impacts!(plan, path)
+    elseif startswith(path, "src/wfs/")
+        add_wfs_impacts!(plan, path)
+    elseif startswith(path, "src/plant/")
+        add_plant_impacts!(plan, path)
+    elseif startswith(path, "src/optics/") || startswith(path, "src/atmosphere/")
+        add_selectors!(plan,
+            ("ci-foundations", "ci-sensors-control", "ci-plant-optics"))
+        request_accelerators!(plan, FullAccelerator)
+    elseif startswith(path, "src/control/")
+        add_selectors!(plan, ("control", "plant-controller-routing"))
+    elseif startswith(path, "src/calibration/")
+        add_selectors!(plan, ("calibration", "control-reconstruction"))
+    elseif startswith(path, "src/tomography/")
+        add_selectors!(plan, ("tomography", "control-reconstruction"))
+    elseif startswith(path, "src/ensembles/")
+        add_selectors!(plan, ("ci-foundations",))
+        plan.run_grouped_cpu = true
+        plan.run_scheduler = true
+    else
+        all_validation!(plan)
+    end
+    return true
+end
+
+function add_extension_impacts!(plan::ValidationPlan, path::String)
+    startswith(path, "ext/") || return false
+    add_selectors!(plan, ("quality", "interface-conformance"))
+    if occursin("CUDA", path)
+        request_cuda!(plan, FullAccelerator)
+    elseif occursin("AMDGPU", path)
+        request_amdgpu!(plan, FullAccelerator)
+    elseif occursin("AppleAccelerate", path)
+        push!(plan.manual_gates, "appleaccelerate")
+    elseif occursin("Metal", path)
+        push!(plan.manual_gates, "metal")
+    elseif occursin("AcceleratedKernels", path) || occursin("Dagger", path)
+        plan.run_grouped_cpu = true
+        plan.run_scheduler = true
+    end
+    return true
+end
+
+function add_test_impacts!(plan::ValidationPlan, path::String)
+    startswith(path, "test/") || return false
+    add_registered_test_impacts!(plan, path) && return true
+    if startswith(path, "test/ci/")
+        add_selectors!(plan, ("quality",))
+    elseif startswith(path, "test/cuda/") || occursin("cuda", lowercase(path))
+        request_cuda!(plan, occursin("detector", path) ?
+            DetectorAccelerator : FullAccelerator)
+    elseif startswith(path, "test/amdgpu/") || occursin("amdgpu", lowercase(path))
+        request_amdgpu!(plan, occursin("detector", path) ?
+            DetectorAccelerator : FullAccelerator)
+    elseif startswith(path, "test/appleaccelerate/")
+        push!(plan.manual_gates, "appleaccelerate")
+    elseif startswith(path, "test/metal/")
+        push!(plan.manual_gates, "metal")
+    elseif startswith(path, "test/schedulers/")
+        plan.run_scheduler = true
+    else
+        all_validation!(plan)
+    end
+    return true
+end
+
+is_documentation_path(path::String) =
+    startswith(path, "docs/") || path in ("README.md", "LICENSE", "LICENSE.md")
+
+function add_path_impacts!(plan::ValidationPlan, raw_path::AbstractString)
+    path = normalized_repository_path(raw_path)
+    if is_documentation_path(path)
+        add_selectors!(plan, path == "docs/glossary.md" ?
+            ("quality", "namespace-authority") : ("quality",))
+        return plan
+    end
+    if path == "Project.toml"
+        return all_validation!(plan)
+    elseif path in ("AGENTS.md", "codecov.yml") ||
+            startswith(path, ".github/workflows/")
+        add_selectors!(plan, ("quality",))
+        path == "codecov.yml" && push!(plan.manual_gates, "coverage")
+        return plan
+    elseif startswith(path, "examples/")
+        add_selectors!(plan, ("reference-tutorials",))
+        return plan
+    elseif startswith(path, "scripts/") || startswith(path, "benchmarks/")
+        add_selectors!(plan, ("quality",))
+        return plan
+    end
+    add_source_impacts!(plan, path) && return plan
+    add_extension_impacts!(plan, path) && return plan
+    add_test_impacts!(plan, path) && return plan
+    return all_validation!(plan)
+end
+
+function plan_validation(paths)
+    plan = ValidationPlan()
+    isempty(paths) && return all_validation!(plan)
+    for path in paths
+        add_path_impacts!(plan, path)
+    end
+    return plan
+end
+
+ordered_selectors(plan::ValidationPlan) =
+    [selector for selector in SELECTOR_ORDER if selector in plan.selectors]
+
+selector_arguments(plan::ValidationPlan) = join(ordered_selectors(plan), ' ')
+selector_input(plan::ValidationPlan) = join(ordered_selectors(plan), ',')
+
+function local_commands(plan::ValidationPlan)
+    commands = Pair{String,String}[]
+    selectors = selector_arguments(plan)
+    plan.run_cpu && push!(commands, "local CPU" =>
+        "julia --project=. --startup-file=no test/ci/run_selected_tests.jl $selectors")
+    plan.run_grouped_cpu && push!(commands, "local grouped CPU" =>
+        "julia --threads=4 --project=. --startup-file=no test/ci/run_selected_tests.jl gate6")
+    plan.run_scheduler && push!(commands, "local scheduler extensions" =>
+        "julia --threads=4 --project=test/schedulers --startup-file=no test/schedulers/runtests.jl")
+    accelerator_target = plan.accelerator_scope == DetectorAccelerator ?
+        "runtests_amdgpu_detectors.jl" : "runtests_amdgpu.jl"
+    plan.run_amdgpu && push!(commands, "local AMDGPU" =>
+        "julia --project=test/amdgpu --startup-file=no test/$accelerator_target")
+    cuda_target = plan.accelerator_scope == DetectorAccelerator ?
+        "runtests_cuda_detectors.jl" : "runtests_cuda.jl"
+    plan.run_cuda && push!(commands, "WSL CUDA" =>
+        "ssh wsl 'cd \"\${AOS_WSL_ROOT:-\$HOME/workspaces/codex/AdaptiveOpticsSim.jl}\" && julia --project=test/cuda --startup-file=no test/$cuda_target'")
+    plan.run_aarch64 && push!(commands, "Raspberry Pi aarch64" =>
+        "ssh raspberrypi 'cd \"\${AOS_RASPBERRYPI_ROOT:-\$HOME/workspaces/codex/AdaptiveOpticsSim.jl}\" && julia --project=. --startup-file=no test/ci/run_selected_tests.jl $selectors'")
+    return commands
+end
+
+function manual_commands(plan::ValidationPlan)
+    commands = Pair{String,String}[]
+    selectors = selector_input(plan)
+    ref = "--ref \"\$(git branch --show-current)\""
+    for gate in ("macos-selector", "windows-selector")
+        gate in plan.manual_gates && push!(commands, gate =>
+            "gh workflow run \"CPU Validation\" $ref -f gate=$gate -f selectors=$selectors")
+    end
+    for gate in ("appleaccelerate", "metal")
+        gate in plan.manual_gates && push!(commands, gate =>
+            "gh workflow run \"CPU Validation\" $ref -f gate=$gate")
+    end
+    "coverage" in plan.manual_gates && push!(commands, "coverage" =>
+        "gh workflow run Coverage $ref")
+    return commands
+end
+
+function changed_paths(base_sha::AbstractString, head_sha::AbstractString="HEAD")
+    isempty(strip(base_sha)) && error("a nonempty base SHA is required")
+    command = Cmd([
+        "git", "-c", "core.quotePath=false", "diff", "--name-status",
+        "-z", "--find-renames", "$(String(base_sha))...$(String(head_sha))",
+    ])
+    fields = split(read(command, String), '\0'; keepempty=false)
+    paths = String[]
+    index = 1
+    while index <= length(fields)
+        status = fields[index]
+        index += 1
+        if !isempty(status) && first(status) in ('R', 'C')
+            index + 1 <= length(fields) || error(
+                "malformed git name-status output for status '$status'")
+            push!(paths, fields[index], fields[index + 1])
+            index += 2
+        else
+            index <= length(fields) || error(
+                "malformed git name-status output for status '$status'")
+            push!(paths, fields[index])
+            index += 1
+        end
+    end
+    return unique!(paths)
+end
+
+function validate_local_markdown_links(repository_root::AbstractString)
+    root = abspath(repository_root)
+    markdown_files = String[]
+    for path in (joinpath(root, "README.md"), joinpath(root, "AGENTS.md"))
+        isfile(path) && push!(markdown_files, path)
+    end
+    docs_root = joinpath(root, "docs")
+    if isdir(docs_root)
+        for (directory, _, files) in walkdir(docs_root), file in files
+            endswith(file, ".md") && push!(markdown_files, joinpath(directory, file))
+        end
+    end
+
+    inline_link = r"!?\[[^\]]*\]\(([^)]+)\)"
+    reference_link = r"^\s*\[[^\]]+\]:\s*(\S+)"m
+    failures = String[]
+    for markdown in markdown_files
+        text = read(markdown, String)
+        destinations = String[]
+        append!(destinations,
+            (match.captures[1] for match in eachmatch(inline_link, text)))
+        append!(destinations,
+            (match.captures[1] for match in eachmatch(reference_link, text)))
+        for raw_destination in destinations
+            destination = strip(raw_destination)
+            startswith(destination, '<') && endswith(destination, '>') &&
+                (destination = destination[2:end-1])
+            destination = first(split(destination, r"\s+\""; limit=2))
+            isempty(destination) && continue
+            startswith(destination, '#') && continue
+            occursin(r"^[A-Za-z][A-Za-z0-9+.-]*:", destination) && continue
+            startswith(destination, '/') && continue
+            local_path = first(split(destination, ('#', '?'); limit=2))
+            local_path = replace(local_path, "%20" => " ")
+            isempty(local_path) && continue
+            resolved = normpath(joinpath(dirname(markdown), local_path))
+            ispath(resolved) || push!(failures,
+                "$(relpath(markdown, root)) -> $destination")
+        end
+    end
+    isempty(failures) || error(
+        "maintained Markdown contains missing local links:\n" * join(failures, '\n'))
+    return nothing
+end
+
+function validate_impact_policy(repository_root::AbstractString=pwd())
+    validate_test_suite_registry()
+    for (path, selectors) in REGISTERED_TEST_PATH_SELECTORS
+        plan = plan_validation((path,))
+        issubset(selectors, plan.selectors) || error(
+            "registered test path '$path' does not select its owning suites")
+    end
+    root = abspath(repository_root)
+    tracked = split(read(`git -C $root ls-files -z`, String), '\0'; keepempty=false)
+    for path in tracked
+        if any(prefix -> startswith(path, prefix), ("src/", "ext/", "test/")) ||
+                path == "Project.toml"
+            plan = plan_validation((path,))
+            (plan.run_cpu || plan.run_cuda || plan.run_amdgpu ||
+                plan.run_aarch64 || plan.run_grouped_cpu ||
+                plan.run_scheduler || !isempty(plan.manual_gates)) || error(
+                    "behavior-bearing path '$path' selects no validation target")
+        end
+    end
+    validate_local_markdown_links(root)
+    return nothing
+end
+
+function parse_cli(arguments)
+    base_sha = nothing
+    head_sha = "HEAD"
+    paths = String[]
+    select_all = false
+    validate = false
+    index = 1
+    while index <= length(arguments)
+        argument = arguments[index]
+        if argument == "--all"
+            select_all = true
+        elseif argument == "--validate-repository"
+            validate = true
+        elseif argument in ("--base-sha", "--head-sha", "--path")
+            index += 1
+            index <= length(arguments) || error("$argument requires a value")
+            value = arguments[index]
+            argument == "--base-sha" && (base_sha = value)
+            argument == "--head-sha" && (head_sha = value)
+            argument == "--path" && push!(paths, value)
+        else
+            error("unknown argument '$argument'")
+        end
+        index += 1
+    end
+    inputs = Int(select_all) + Int(base_sha !== nothing) + Int(!isempty(paths))
+    inputs == 1 || error("use exactly one of --all, --base-sha, or --path")
+    return (; base_sha, head_sha, paths, select_all, validate)
+end
+
+function print_plan(io::IO, paths, plan::ValidationPlan)
+    println(io, "Changed paths: ", join(paths, ", "))
+    println(io, "Selectors: ", join(ordered_selectors(plan), ", "))
+    println(io, "Local validation:")
+    for (label, command) in local_commands(plan)
+        println(io, "  [$label] $command")
+    end
+    manual = manual_commands(plan)
+    if !isempty(manual)
+        println(io, "Optional manual GitHub gates (require explicit approval):")
+        for (label, command) in manual
+            println(io, "  [$label] $command")
+        end
+    end
+    return nothing
+end
+
+function main(arguments=ARGS)
+    options = parse_cli(arguments)
+    options.validate && validate_impact_policy()
+    paths = if options.select_all
+        String[]
+    elseif options.base_sha !== nothing
+        changed_paths(options.base_sha, options.head_sha)
+    else
+        options.paths
+    end
+    plan = options.select_all ? all_validation!(ValidationPlan()) :
+        plan_validation(paths)
+    print_plan(stdout, options.select_all ? ["<all>"] : paths, plan)
+    return nothing
+end
+
+abspath(PROGRAM_FILE) == abspath(@__FILE__) && main()

--- a/test/ci/run_selected_tests.jl
+++ b/test/ci/run_selected_tests.jl
@@ -1,0 +1,9 @@
+#!/usr/bin/env julia
+
+using Pkg
+
+raw_selectors = isempty(ARGS) ?
+    get(ENV, "ADAPTIVEOPTICS_TEST_SELECTORS", "") : join(ARGS, ',')
+selectors = strip.(split(raw_selectors, ','))
+any(isempty, selectors) && error("test selectors must be nonempty")
+Pkg.test(test_args=selectors)

--- a/test/ci/test_impact_planner.jl
+++ b/test/ci/test_impact_planner.jl
@@ -1,0 +1,141 @@
+#!/usr/bin/env julia
+
+using Test
+
+include(joinpath(@__DIR__, "impact_planner.jl"))
+
+@testset "local validation impact planner" begin
+    @test Set(CLOSURE_SELECTORS) == Set(first.(TEST_CI_SHARD_SPECS))
+
+    docs = plan_validation(("docs/user-guide.md",))
+    @test docs.selectors == Set(("quality",))
+    @test docs.run_cpu
+    @test !docs.run_cuda
+    @test !docs.run_amdgpu
+    @test isempty(docs.manual_gates)
+
+    glossary = plan_validation(("docs/glossary.md",))
+    @test glossary.selectors == Set(("quality", "namespace-authority"))
+
+    cmos = plan_validation(("src/detectors/cmos.jl",))
+    @test "detector-cmos" in cmos.selectors
+    @test "detector-shared" in cmos.selectors
+    @test "detector-thermal" in cmos.selectors
+    @test "plant-device-model-matrix" in cmos.selectors
+    @test cmos.accelerator_scope == DetectorAccelerator
+    @test cmos.run_cuda
+    @test cmos.run_amdgpu
+    @test !cmos.run_aarch64
+
+    ccd = plan_validation(("src/detectors/ccd.jl",))
+    @test "detector-ccd" in ccd.selectors
+    @test "detector-skipper" in ccd.selectors
+
+    detector_common = plan_validation(("src/detectors/pipeline.jl",))
+    @test "detectors" in detector_common.selectors
+    @test detector_common.accelerator_scope == DetectorAccelerator
+
+    shack_hartmann = plan_validation(("src/wfs/shack_hartmann.jl",))
+    @test shack_hartmann.selectors == Set((
+        "wfs-acquisition-ownership", "wfs-common", "wfs-shack-hartmann"))
+    @test shack_hartmann.accelerator_scope == FullAccelerator
+
+    plant_time = plan_validation(("src/plant/time.jl",))
+    @test plant_time.selectors ==
+        Set(("plant-time", "prepared-execution-contracts"))
+    @test !plant_time.run_cuda
+    @test !plant_time.run_grouped_cpu
+
+    plant_batching = plan_validation(("src/plant/device_batching.jl",))
+    @test "plant-device-batching" in plant_batching.selectors
+    @test plant_batching.run_grouped_cpu
+    @test plant_batching.accelerator_scope == FullAccelerator
+
+    atmosphere = plan_validation(("src/atmosphere/multilayer.jl",))
+    @test atmosphere.selectors == Set((
+        "ci-foundations", "ci-sensors-control", "ci-plant-optics"))
+    @test atmosphere.accelerator_scope == FullAccelerator
+
+    registered = plan_validation(("test/testsets/detector_cmos.jl",))
+    @test registered.selectors == Set(("detector-cmos",))
+    @test registered.accelerator_scope == DetectorAccelerator
+
+    shared_fixture = plan_validation(("test/detector_test_fixtures.jl",))
+    @test issubset(Set(DETECTOR_TEST_SUITE_NAMES), shared_fixture.selectors)
+
+    cuda_extension = plan_validation(("ext/AdaptiveOpticsSimCUDAExt.jl",))
+    @test cuda_extension.run_cuda
+    @test !cuda_extension.run_amdgpu
+    @test cuda_extension.accelerator_scope == FullAccelerator
+
+    apple_extension =
+        plan_validation(("ext/AdaptiveOpticsSimAppleAccelerateExt.jl",))
+    @test apple_extension.manual_gates == Set(("appleaccelerate",))
+
+    workflow = plan_validation((".github/workflows/cpu-validation.yml",))
+    @test workflow.selectors == Set(("quality",))
+    @test isempty(workflow.manual_gates)
+    @test !workflow.run_cuda
+
+    planner = plan_validation(("test/ci/impact_planner.jl",))
+    @test planner.selectors == Set(("quality",))
+    @test !planner.run_cuda
+    @test !planner.run_amdgpu
+
+    project = plan_validation(("Project.toml",))
+    @test Set(CLOSURE_SELECTORS) == project.selectors
+    @test project.run_aarch64
+    @test project.run_grouped_cpu
+    @test project.run_scheduler
+    @test project.accelerator_scope == FullAccelerator
+    @test project.manual_gates == Set((
+        "macos-selector", "windows-selector", "appleaccelerate",
+        "metal", "coverage"))
+
+    unknown = plan_validation(("new_runtime/component.jl",))
+    @test unknown.selectors == project.selectors
+    @test unknown.manual_gates == project.manual_gates
+    @test_throws ArgumentError plan_validation(("../outside.jl",))
+
+    cmos_commands = Dict(local_commands(cmos))
+    @test occursin("detector-cmos", cmos_commands["local CPU"])
+    @test occursin("runtests_amdgpu_detectors.jl",
+        cmos_commands["local AMDGPU"])
+    @test occursin("ssh wsl", cmos_commands["WSL CUDA"])
+    @test !haskey(cmos_commands, "Raspberry Pi aarch64")
+
+    project_commands = Dict(local_commands(project))
+    @test occursin("ssh raspberrypi",
+        project_commands["Raspberry Pi aarch64"])
+    @test occursin("runtests_cuda.jl", project_commands["WSL CUDA"])
+    @test length(manual_commands(project)) == 5
+    @test occursin("-f gate=macos-selector",
+        Dict(manual_commands(project))["macos-selector"])
+    @test occursin("--ref \"\$(git branch --show-current)\"",
+        Dict(manual_commands(project))["macos-selector"])
+
+    @test_throws ErrorException parse_cli(String[])
+    @test_throws ErrorException parse_cli(["--all", "--path", "src/core/config.jl"])
+    @test parse_cli(["--all"]).select_all
+    @test parse_cli(["--path", "src/core/config.jl"]).paths ==
+        ["src/core/config.jl"]
+
+    mktempdir() do repository
+        run(`git -C $repository init -q`)
+        run(`git -C $repository config user.email validation@example.invalid`)
+        run(`git -C $repository config user.name "Validation Test"`)
+        mkpath(joinpath(repository, "src"))
+        write(joinpath(repository, "src", "old.jl"), "old\n")
+        run(`git -C $repository add src/old.jl`)
+        run(`git -C $repository commit -qm baseline`)
+        base_sha = readchomp(`git -C $repository rev-parse HEAD`)
+        run(`git -C $repository mv src/old.jl src/new.jl`)
+        run(`git -C $repository commit -qm rename`)
+        paths = cd(repository) do
+            changed_paths(base_sha)
+        end
+        @test Set(paths) == Set(("src/old.jl", "src/new.jl"))
+    end
+
+    @test isnothing(validate_impact_policy(joinpath(@__DIR__, "..", "..")))
+end


### PR DESCRIPTION
## Summary

- add a conservative local change-impact planner backed by the existing Julia test registry
- emit bounded CPU, AMDGPU, CUDA, aarch64, and optional manual platform commands
- make CPU Validation a one-gate-at-a-time manual workflow
- reduce Coverage to one explicit manual full-project job

## Why

Development was launching broad GitHub-hosted matrices too frequently. This keeps all support gates available while moving routine selection and validation to local hardware.

## Local validation

- `julia --startup-file=no test/ci/test_impact_planner.jl` — 66/66 passed
- `ADAPTIVEOPTICS_TEST_SELECTORS=quality JULIA_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 julia --project=. --startup-file=no test/ci/run_selected_tests.jl` — passed
- planner repository validation — registry and maintained Markdown links passed
- local YAML structural validation — four manual-only workflows, nine mutually exclusive CPU gates, one coverage job
- `git diff --check` — passed

GitHub Actions were intentionally not dispatched. All workflows in scope remain manual-only.

Closes #291