### PR TITLE
Remove erased package storage

### DIFF
--- a/src/AdaptiveOpticsSim.jl
+++ b/src/AdaptiveOpticsSim.jl
@@ -4,6 +4,7 @@ __precompile__(true)
 
 using AbstractFFTs
 import FFTW
+using FixedSizeArrays: FixedSizeVectorDefault
 using KernelAbstractions
 using LinearAlgebra
 using Logging

--- a/src/algorithm_graphs/graph_files.jl
+++ b/src/algorithm_graphs/graph_files.jl
@@ -117,11 +117,7 @@ _normalize_toml_value(value::Union{Bool,Integer,AbstractFloat,AbstractString}) =
     value
 
 function _normalize_toml_value(values::AbstractVector)
-    builder = Vector{Any}(undef, length(values))
-    for index in eachindex(values)
-        builder[index] = _normalize_toml_value(values[index])
-    end
-    return Tuple(builder)
+    return Tuple(_normalize_toml_value(value) for value in values)
 end
 
 
@@ -139,7 +135,7 @@ function _normalize_toml_value(value)
 end
 
 function _table_or_empty(table::AbstractDict, key::String, context::AbstractString)
-    value = get(table, key, Dict{String,Any}())
+    value = get(table, key, Dict{String,Union{}}())
     value isa AbstractDict || throw(_file_error(
         context,
         "field '$key' must be a table",
@@ -152,8 +148,8 @@ function _table_array_or_empty(
     key::String,
     context::AbstractString,
 )
-    value = get(table, key, Any[])
-    value isa AbstractVector || throw(_file_error(
+    value = get(table, key, ())
+    value isa AbstractVector || value isa Tuple || throw(_file_error(
         context,
         "field '$key' must be an array of tables",
     ))
@@ -1513,12 +1509,11 @@ function _parse_file_parameter(
     return sparse_parameter(destination, values)
 end
 
-function _parse_entries(entries::AbstractVector, parse_entry)
-    builder = Vector{Any}(undef, length(entries))
-    for (index, entry) in pairs(entries)
-        builder[index] = parse_entry(entry, Int(index))
-    end
-    return Tuple(builder)
+function _parse_entries(entries, parse_entry)
+    return Tuple(
+        parse_entry(entry, Int(index))
+        for (index, entry) in pairs(entries)
+    )
 end
 
 """

--- a/src/atmosphere/atmospheres.jl
+++ b/src/atmosphere/atmospheres.jl
@@ -6,6 +6,7 @@ geometry, prepared directional rendering, and atmosphere-coupled propagation.
 """
 module Atmospheres
 
+using FixedSizeArrays: FixedSizeVector, FixedSizeVectorDefault
 using KernelAbstractions
 using LinearAlgebra
 using Random
@@ -21,6 +22,7 @@ import ..AdaptiveOpticsSim:
     NumericalConditionError,
     ScientificProfile,
     UnsupportedAlgorithm,
+    _fixed_size_union_vector,
     _scaled_kv56_scalar,
     atmosphere_profile,
     default_fidelity_profile,

--- a/src/atmosphere/definitions.jl
+++ b/src/atmosphere/definitions.jl
@@ -7,9 +7,12 @@ struct AtmosphereLayerDefinition{T<:AbstractFloat}
     altitude::T
 end
 
-struct _FixedAtmosphereLayerDefinitions{T<:AbstractFloat} <:
+struct _FixedAtmosphereLayerDefinitions{
+    T<:AbstractFloat,
+    S<:Tuple{Vararg{AtmosphereLayerDefinition{T}}},
+} <:
     AbstractVector{AtmosphereLayerDefinition{T}}
-    _storage::Tuple{Vararg{AtmosphereLayerDefinition{T}}}
+    _storage::S
 end
 
 Base.size(layers::_FixedAtmosphereLayerDefinitions) =
@@ -59,19 +62,25 @@ Layer parameters are copied into fixed-size homogeneous host configuration
 storage. Explicit `layer_ids` are required because tuple position and altitude
 are not stable stochastic-owner identities.
 """
-struct MultiLayerAtmosphereDefinition{T<:AbstractFloat} <:
+struct MultiLayerAtmosphereDefinition{
+    T<:AbstractFloat,
+    L<:_FixedAtmosphereLayerDefinitions{T},
+} <:
     AbstractTimedAtmosphereDefinition
     r0::T
     L0::T
-    layers::_FixedAtmosphereLayerDefinitions{T}
+    layers::L
 end
 
 """Cold declaration of one infinite boundary-injection multilayer atmosphere."""
-struct InfiniteMultiLayerAtmosphereDefinition{T<:AbstractFloat} <:
+struct InfiniteMultiLayerAtmosphereDefinition{
+    T<:AbstractFloat,
+    L<:_FixedAtmosphereLayerDefinitions{T},
+} <:
     AbstractTimedAtmosphereDefinition
     r0::T
     L0::T
-    layers::_FixedAtmosphereLayerDefinitions{T}
+    layers::L
     screen_resolution::Union{Nothing,Int}
     stencil_size::Union{Nothing,Int}
 end
@@ -109,9 +118,8 @@ function _cold_atmosphere_layer_definitions(
     length(layer_ids) == n_layers || throw(InvalidConfiguration(
         "layer_ids length must match fractional_cn2"))
 
-    layers = Memory{AtmosphereLayerDefinition{T}}(undef, n_layers)
-    @inbounds for index in eachindex(layers)
-        layers[index] = AtmosphereLayerDefinition(
+    layers = Tuple(
+        AtmosphereLayerDefinition(
             _as_atmosphere_layer_id(layer_ids[index]),
             _converted_nonnegative_finite(fractional_cn2[index], T,
                 "atmosphere Cn2 fraction"),
@@ -122,12 +130,13 @@ function _cold_atmosphere_layer_definitions(
             _converted_nonnegative_finite(altitude[index], T,
                 "atmosphere layer altitude"),
         )
-    end
+        for index in 1:n_layers
+    )
     isapprox(sum(layer -> layer.cn2_fraction, layers), one(T);
         atol=T(1e-6), rtol=T(1e-6)) || throw(InvalidConfiguration(
         "fractional_cn2 must sum to 1"))
     _require_unique_cold_atmosphere_layer_ids(layers)
-    return _FixedAtmosphereLayerDefinitions{T}(Tuple(layers))
+    return _FixedAtmosphereLayerDefinitions{T,typeof(layers)}(layers)
 end
 
 function MultiLayerAtmosphereDefinition(;
@@ -147,7 +156,7 @@ function MultiLayerAtmosphereDefinition(;
         altitude,
         layer_ids,
     )
-    return MultiLayerAtmosphereDefinition{T}(
+    return MultiLayerAtmosphereDefinition{T,typeof(layers)}(
         _converted_positive_finite(r0, T, "atmosphere Fried parameter r0"),
         _converted_positive_finite(L0, T, "atmosphere outer scale L0"),
         layers,
@@ -197,7 +206,7 @@ function InfiniteMultiLayerAtmosphereDefinition(;
         altitude,
         layer_ids,
     )
-    return InfiniteMultiLayerAtmosphereDefinition{T}(
+    return InfiniteMultiLayerAtmosphereDefinition{T,typeof(layers)}(
         _converted_positive_finite(r0, T, "atmosphere Fried parameter r0"),
         _converted_positive_finite(L0, T, "atmosphere outer scale L0"),
         layers,

--- a/src/atmosphere/direction_batch.jl
+++ b/src/atmosphere/direction_batch.jl
@@ -14,12 +14,10 @@ struct ExtractedScreenDirectionBatchCapability <:
 struct UnsupportedAtmosphereDirectionBatchCapability <:
     AbstractAtmosphereDirectionBatchCapability end
 
-abstract type AbstractAtmosphereSourceGeometryBinding end
-
 struct AtmosphereSourceGeometryBinding{
     S,
     T<:AbstractFloat,
-} <: AbstractAtmosphereSourceGeometryBinding
+}
     source::S
     signature::NTuple{3,T}
 end
@@ -69,10 +67,10 @@ struct AtmosphereDirectionBatchParams{
     T<:AbstractFloat,
     I<:AtmosphereIdentity,
     C<:AbstractAtmosphereDirectionBatchCapability,
-    S,
-    G<:Memory{<:AbstractAtmosphereSourceGeometryBinding},
-    R<:Memory,
-    L<:Memory,
+    S<:FixedSizeVector,
+    G<:FixedSizeVector,
+    R<:FixedSizeVector,
+    L<:FixedSizeVector,
     M<:OpticalPlaneMetadata,
 }
     identity::I
@@ -102,10 +100,10 @@ function AtmosphereDirectionBatchParams{T}(
     T<:AbstractFloat,
     I<:AtmosphereIdentity,
     C<:AbstractAtmosphereDirectionBatchCapability,
-    S,
-    G<:Memory{<:AbstractAtmosphereSourceGeometryBinding},
-    R<:Memory,
-    L<:Memory,
+    S<:FixedSizeVector,
+    G<:FixedSizeVector,
+    R<:FixedSizeVector,
+    L<:FixedSizeVector,
     M<:OpticalPlaneMetadata,
 }
     return AtmosphereDirectionBatchParams{
@@ -172,12 +170,12 @@ end
     atmosphere_direction_metadata(prepared)
 
 @inline function _freeze_batch_sources(::Nothing)
-    return (nothing,)
+    return _fixed_size_union_vector((nothing,))
 end
 
 function _freeze_batch_sources(src::AbstractSource)
     require_leaf_source(src, "atmosphere direction batch source")
-    return (freeze_source(src),)
+    return _fixed_size_union_vector((freeze_source(src),))
 end
 
 function _freeze_batch_sources(
@@ -200,7 +198,7 @@ function _freeze_batch_sources(
             "numeric and radiometric storage contract"))
         frozen[direction] = source
     end
-    return frozen
+    return FixedSizeVectorDefault{S}(frozen)
 end
 
 function _freeze_batch_sources(ast::Asterism)
@@ -222,32 +220,22 @@ function _copy_source_geometry_bindings(
     sources,
     ::Type{T},
 ) where {T<:AbstractFloat}
-    bindings = Memory{AbstractAtmosphereSourceGeometryBinding}(
-        undef,
-        length(sources),
-    )
-    @inbounds for direction in eachindex(sources)
-        source = sources[direction]
-        bindings[direction] = AtmosphereSourceGeometryBinding(
+    bindings = (
+        AtmosphereSourceGeometryBinding(
             source,
             source_geometry_signature(source, T),
         )
-    end
-    return bindings
+        for source in sources
+    )
+    return _fixed_size_union_vector(bindings)
 end
 
 function _copy_source_bindings(sources)
-    bindings = Memory{eltype(sources)}(undef, length(sources))
-    @inbounds for direction in eachindex(sources)
-        bindings[direction] = sources[direction]
-    end
-    return bindings
+    return _fixed_size_union_vector(sources)
 end
 
-function _copy_layer_bindings(layers::AbstractVector{L}) where {L}
-    bindings = Memory{L}(undef, length(layers))
-    copyto!(bindings, layers)
-    return bindings
+function _copy_layer_bindings(layers::AbstractVector)
+    return _fixed_size_union_vector(layers)
 end
 
 function _prepare_batch_geometry(

--- a/src/core/config.jl
+++ b/src/core/config.jl
@@ -1,32 +1,58 @@
 config_value(x::Symbol) = String(x)
-config_value(x::AbstractArray) = [config_value(v) for v in x]
-config_value(x::Tuple) = [config_value(v) for v in x]
-config_value(x::NamedTuple) = Dict(string(k) => config_value(v) for (k, v) in pairs(x))
-config_value(x::AbstractDict) = Dict(string(k) => config_value(v) for (k, v) in pairs(x))
+function config_value(x::AbstractArray)
+    normalized_type = Union{}
+    for value in x
+        normalized_type = Union{
+            normalized_type,
+            typeof(config_value(value)),
+        }
+    end
+    normalized = Array{normalized_type}(undef, size(x))
+    index = 1
+    for value in x
+        normalized[index] = config_value(value)
+        index += 1
+    end
+    return normalized
+end
+
+config_value(x::Tuple) = _concrete_union_vector(map(config_value, x))
+config_value(x::NamedTuple) = config_dict(x)
+config_value(x::AbstractDict) = config_dict(x)
 config_value(x::Optics.AbstractOpticalElement) = config_dict(x)
 config_value(x::Nothing) = nothing
 config_value(x) = x
 
-function config_dict(x::AbstractDict)
-    out = Dict{String, Any}()
-    for (k, v) in pairs(x)
-        val = config_value(v)
-        if val !== nothing
-            out[string(k)] = val
-        end
+@inline function _config_entry(key, value)
+    normalized = config_value(value)
+    normalized === nothing && return nothing
+    return string(key) => normalized
+end
+
+function _config_entries(values)
+    candidates = (
+        _config_entry(key, value)
+        for (key, value) in pairs(values)
+    )
+    return Tuple(Iterators.filter(
+        entry -> entry !== nothing,
+        candidates,
+    ))
+end
+
+function _concrete_config_dict(entries::Tuple)
+    Value = Union{map(entry -> typeof(last(entry)), entries)...}
+    out = Dict{String,Value}()
+    for entry in entries
+        out[first(entry)] = last(entry)
     end
     return out
 end
 
+config_dict(x::AbstractDict) = _concrete_config_dict(_config_entries(x))
+
 function config_dict(x::NamedTuple)
-    out = Dict{String, Any}()
-    for (k, v) in pairs(x)
-        val = config_value(v)
-        if val !== nothing
-            out[string(k)] = val
-        end
-    end
-    return out
+    return _concrete_config_dict(_config_entries(x))
 end
 
 function config_dict(x)
@@ -35,20 +61,21 @@ function config_dict(x)
         if hasproperty(x, :params)
             return config_dict(getfield(x, :params))
         end
-        out = Dict{String, Any}()
-        for name in fieldnames(T)
-            val = config_value(getfield(x, name))
-            if val !== nothing
-                out[string(name)] = val
-            end
-        end
-        return out
+        candidates = (
+            _config_entry(name, getfield(x, name))
+            for name in fieldnames(T)
+        )
+        entries = Tuple(Iterators.filter(
+            entry -> entry !== nothing,
+            candidates,
+        ))
+        return _concrete_config_dict(entries)
     end
     return config_value(x)
 end
 
 function snapshot_config(; kwargs...)
-    return Dict(string(k) => config_dict(v) for (k, v) in pairs(kwargs))
+    return config_dict((; kwargs...))
 end
 
 function write_config_json(args...; kwargs...)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -1,3 +1,32 @@
+function _concrete_union_element_type(values)
+    element_type = Union{}
+    for value in values
+        element_type = Union{element_type,typeof(value)}
+    end
+    return element_type
+end
+
+function _union_members_are_concrete(::Type{T}) where {T}
+    T === Union{} && return true
+    return all(isconcretetype, Base.uniontypes(T))
+end
+
+function _concrete_union_vector(values)
+    element_type = _concrete_union_element_type(values)
+    builder = Vector{element_type}(undef, length(values))
+    index = 1
+    for value in values
+        builder[index] = value
+        index += 1
+    end
+    return builder
+end
+
+function _fixed_size_union_vector(values)
+    builder = _concrete_union_vector(values)
+    return FixedSizeVectorDefault{eltype(builder)}(builder)
+end
+
 @kernel function fftshift2d_kernel!(dest, src, sx::Int, sy::Int, n::Int, m::Int)
     i, j = @index(Global, NTuple)
     if i <= n && j <= m

--- a/src/optics/asterism.jl
+++ b/src/optics/asterism.jl
@@ -1,13 +1,33 @@
-struct Asterism{S<:AbstractSource,V<:AbstractVector{S}} <: AbstractSource
+"""
+An ordered finite collection of leaf sources.
+
+Construction freezes every source and seals the collection at its final
+cardinality. Heterogeneous source families use a concrete union element type
+rather than abstract source storage.
+"""
+struct Asterism{V<:FixedSizeVector{<:AbstractSource}} <: AbstractSource
     sources::V
-    function Asterism(sources::AbstractVector{S}) where {S<:AbstractSource}
-        frozen = Vector{S}(undef, length(sources))
-        @inbounds for i in eachindex(sources)
-            require_leaf_source(sources[i], "Asterism child")
-            frozen[i] = freeze_source(sources[i])
-        end
-        return new{S,typeof(frozen)}(frozen)
+    function Asterism{V}(sources::V) where {
+        V<:FixedSizeVector{<:AbstractSource},
+    }
+        _union_members_are_concrete(eltype(V)) || throw(
+            InvalidConfiguration(
+                "asterism storage must have concrete source type members",
+            ),
+        )
+        return new{V}(sources)
     end
+end
+
+@inline function _freeze_asterism_source(source::AbstractSource)
+    require_leaf_source(source, "Asterism child")
+    return freeze_source(source)
+end
+
+function Asterism(sources::AbstractVector{<:AbstractSource})
+    frozen = Tuple(_freeze_asterism_source(source) for source in sources)
+    storage = _fixed_size_union_vector(frozen)
+    return Asterism{typeof(storage)}(storage)
 end
 
 freeze_source(ast::Asterism) = Asterism(ast.sources)

--- a/src/optics/optics.jl
+++ b/src/optics/optics.jl
@@ -16,6 +16,8 @@ import ..AdaptiveOpticsSim:
     DimensionMismatchError,
     InvalidConfiguration,
     UnsupportedAlgorithm,
+    _fixed_size_union_vector,
+    _union_members_are_concrete,
     circshift2d!,
     config_value,
     fftfreq!,

--- a/test/testsets/algorithm_graphs.jl
+++ b/test/testsets/algorithm_graphs.jl
@@ -1662,6 +1662,13 @@ end
 end
 
 @testset "TOML graph files compile to native graph definitions" begin
+    normalized_toml =
+        AdaptiveOpticsSim.AlgorithmGraphs._normalize_toml_value(
+            Any[1, "two", Any[true, 3.0]],
+        )
+    @test normalized_toml == (1, "two", (true, 3.0))
+    @test isconcretetype(typeof(normalized_toml))
+
     residual = Float32[1, 2]
     basis = zeros(Float32, 2, 2, 2)
     fill!(@view(basis[:, :, 1]), 1.0f0)

--- a/test/testsets/atmosphere.jl
+++ b/test/testsets/atmosphere.jl
@@ -60,6 +60,9 @@ end
     )
     copied_layers = copy(multilayer_definition.layers)
     copied_layers[1] = copied_layers[2]
+    @test all(isconcretetype, fieldtypes(typeof(multilayer_definition)))
+    @test all(isconcretetype,
+        fieldtypes(typeof(multilayer_definition.layers)))
     @test multilayer_definition.layers[1].id == AtmosphereLayerID(:ground)
     @test_throws CanonicalIndexError multilayer_definition.layers[1] =
         multilayer_definition.layers[2]

--- a/test/testsets/atmosphere_direction_batch.jl
+++ b/test/testsets/atmosphere_direction_batch.jl
@@ -67,6 +67,11 @@ function direction_batch_test_sources(::Type{T}=Float64) where {
     ])
 end
 
+function direction_batch_has_concrete_members(::Type{T}) where {T}
+    members = T isa Union ? Base.uniontypes(T) : (T,)
+    return all(isconcretetype, members)
+end
+
 mutable struct MutableDirectionSource{T<:AbstractFloat} <:
     AdaptiveOpticsSim.Optics.AbstractSource
     coordinates_xy_arcsec::NTuple{2,T}
@@ -125,6 +130,20 @@ end
             output,
         )
         @test prepared isa PreparedAtmosphereDirectionBatch
+        @test prepared.params.sources isa FixedSizeVector
+        @test prepared.params.source_geometry_bindings isa FixedSizeVector
+        @test prepared.params.source_bindings isa FixedSizeVector
+        @test prepared.params.layer_bindings isa FixedSizeVector
+        @test all(
+            direction_batch_has_concrete_members(eltype(storage))
+            for storage in (
+                prepared.params.sources,
+                prepared.params.source_geometry_bindings,
+                prepared.params.source_bindings,
+                prepared.params.layer_bindings,
+            )
+        )
+        @test all(isconcretetype, fieldtypes(typeof(prepared.params)))
         @test atmosphere_direction_output(prepared) === output
         @test atmosphere_direction_count(prepared) == length(sources)
         @test atmosphere_direction_capacity(prepared) == length(sources)
@@ -149,7 +168,11 @@ end
             T(1e-3);
             rng=MersenneTwister(70),
         )
-        rendered = render_atmosphere_directions!(prepared, atm, epoch)
+        rendered = @inferred render_atmosphere_directions!(
+            prepared,
+            atm,
+            epoch,
+        )
         reference = serial_atmosphere_direction_stack(
             atm,
             tel,

--- a/test/testsets/core_optics.jl
+++ b/test/testsets/core_optics.jl
@@ -718,6 +718,16 @@ end
         [0.5, 0.5])
     spectral_leaf = with_spectrum(physical_source, source_bundle)
     directional = Asterism([physical_source])
+    @test directional.sources isa FixedSizeVector
+    @test isconcretetype(eltype(directional.sources))
+    erased_sources = AdaptiveOpticsSim.FixedSizeVectorDefault{
+        AbstractSource,
+    }(AbstractSource[physical_source])
+    normalized_directional = Asterism(erased_sources)
+    @test isconcretetype(eltype(normalized_directional.sources))
+    @test_throws InvalidConfiguration Asterism{typeof(erased_sources)}(
+        erased_sources,
+    )
     extended = with_extended_source(physical_source,
         PointCloudSourceModel([(0.0, 0.0)], [1.0]))
     third_party_expansion = TestExpandedSourceWrapper(physical_source)

--- a/test/testsets/quality.jl
+++ b/test/testsets/quality.jl
@@ -20,6 +20,39 @@ end
 
 @test AdaptiveOpticsSim.PROJECT_STATUS == :in_development
 
+@testset "Implementation storage policy" begin
+    repository = pkgdir(AdaptiveOpticsSim)
+    implementation_paths = String[]
+    for directory in ("src", "ext")
+        for (root, _, files) in walkdir(joinpath(repository, directory))
+            for file in files
+                endswith(file, ".jl") || continue
+                push!(implementation_paths, joinpath(root, file))
+            end
+        end
+    end
+    sort!(implementation_paths)
+
+    forbidden = (
+        "direct Memory storage" => r"\bMemory\s*(?:\{|\()",
+        "Any collection construction" =>
+            r"\b(?:Array|Vector|Matrix|Dict|Set|Ref|FixedSizeArray|FixedSizeVector)\s*\{[^}\n]*\bAny\b[^\n]*\}\s*\(",
+        "Any array literal" => r"\bAny\s*\[",
+        "Any field or collection-field storage" =>
+            r"(?m)^\s*[A-Za-z_]\w*\s*::\s*(?:Any|(?:Array|Vector|Matrix|Dict|Set|Ref|FixedSizeArray|FixedSizeVector)\s*\{[^\n}]*\bAny\b[^\n]*\})\s*$",
+    )
+    violations = String[]
+    for path in implementation_paths
+        source = read(path, String)
+        relative = relpath(path, repository)
+        for (label, pattern) in forbidden
+            occursin(pattern, source) || continue
+            push!(violations, "$relative: $label")
+        end
+    end
+    @test isempty(violations)
+end
+
 @testset "Selective test registry" begin
     @test resolve_test_suites(String[]) === TEST_SUITE_SPECS
     @test resolve_test_suites(["all"]) === TEST_SUITE_SPECS

--- a/test/testsets/reference_and_tutorials.jl
+++ b/test/testsets/reference_and_tutorials.jl
@@ -74,6 +74,34 @@
     @test cfg["src"]["radiometry"] == "physical_photon_irradiance"
     @test cfg["src"]["radiometric_value"] ==
         source_radiometric_value(src)
+    cfg_members = valtype(typeof(cfg)) isa Union ?
+        Base.uniontypes(valtype(typeof(cfg))) :
+        (valtype(typeof(cfg)),)
+    @test all(isconcretetype, cfg_members)
+
+    normalized = AdaptiveOpticsSim.config_dict(Dict(
+        "mixed" => Any[1, "two", Any[true, 3.0]],
+        "nested" => Dict("value" => 4),
+        "omitted" => nothing,
+    ))
+    @test normalized["mixed"] == Any[1, "two", Any[true, 3.0]]
+    @test eltype(normalized["mixed"]) !== Any
+    @test eltype(normalized["mixed"][3]) !== Any
+    @test normalized["nested"] == Dict("value" => 4)
+    @test !haskey(normalized, "omitted")
+    matrix = reshape(Any[1, "two", 3.0, true], 2, 2)
+    normalized_matrix = AdaptiveOpticsSim.config_value(matrix)
+    @test normalized_matrix == matrix
+    @test size(normalized_matrix) == size(matrix)
+    @test eltype(normalized_matrix) !== Any
+    normalized_view = AdaptiveOpticsSim.config_value(@view matrix[:, :])
+    @test normalized_view == matrix
+    @test normalized_view isa Matrix
+    @test eltype(normalized_view) !== Any
+    normalized_members = valtype(typeof(normalized)) isa Union ?
+        Base.uniontypes(valtype(typeof(normalized))) :
+        (valtype(typeof(normalized)),)
+    @test all(isconcretetype, normalized_members)
     @test !isdefined(AdaptiveOpticsSim, :write_config_toml)
 
     project = TOML.parsefile(joinpath(pkgdir(AdaptiveOpticsSim),


### PR DESCRIPTION
## Summary

- replace direct package Memory ownership with immutable tuple declarations or sealed FixedSizeVector execution storage
- normalize heterogeneous Asterism and atmosphere-direction bindings to concrete union element types and close the generated-constructor bypass
- remove Any-backed graph/config builders while preserving dense array shape and JSON serialization behavior
- add source-policy, constructor, inference, array-wrapper, and zero-allocation regressions

## Local validation

- Julia 1.12.7, one thread: Pkg.test with coverage disabled and dependency re-resolution disabled — passed (51 tutorial passes and 2 pre-existing broken expectations)
- local AMDGPU hardware target — 655/655 passed
- JSON3 1.14.3 extension normalization and file round-trip — passed
- git diff --check — passed
- direct src/ext scan for Memory construction and Any-backed collections — clean

CUDA was attempted through the configured WSL SSH target, but the forwarding socket did not return an SSH banner. This is recorded as target unavailability, not a test failure; the corresponding AMDGPU hardware path passed.